### PR TITLE
options: Fix locale problem with std::stof

### DIFF
--- a/core/options.cpp
+++ b/core/options.cpp
@@ -4,6 +4,10 @@
  *
  * options.cpp - common program options helpers
  */
+
+#include <locale.h>
+#include <stdlib.h>
+
 #include <algorithm>
 #include <fcntl.h>
 #include <iomanip>
@@ -45,7 +49,6 @@ static const std::map<libcamera::PixelFormat, unsigned int> bayer_formats =
 	{ libcamera::formats::SBGGR16,       16 },
 	{ libcamera::formats::SGBRG16,       16 },
 };
-
 
 Mode::Mode(std::string const &mode_string)
 {
@@ -90,6 +93,34 @@ static int xioctl(int fd, unsigned long ctl, void *arg)
 		ret = ioctl(fd, ctl, arg);
 	} while (ret == -1 && errno == EINTR && num_tries-- > 0);
 	return ret;
+}
+
+class Locale
+{
+public:
+	Locale(const char *l)
+	{
+		locale_ = newlocale(LC_ALL_MASK, l, 0);
+	}
+
+	~Locale()
+	{
+		freelocale(locale_);
+	}
+
+	const locale_t &Get() const
+	{
+		return locale_;
+	}
+
+private:
+	locale_t locale_;
+};
+
+float strtof_locale(const char *str, char **endptr)
+{
+	static Locale c_locale("C");
+	return strtof_l(str, endptr, c_locale.Get());
 }
 
 bool Options::Parse(int argc, char *argv[])

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -38,6 +38,8 @@ struct Mode
 	std::string ToString() const;
 };
 
+float strtof_locale(const char *str, char **endptr);
+
 template <typename DEFAULT>
 struct TimeVal
 {
@@ -57,10 +59,11 @@ struct TimeVal
 
 		try
 		{
-			std::size_t end_pos;
-			float f = std::stof(s, &end_pos);
+			char *end;
+			float f = strtof_locale(s.c_str(), &end);
 			value = std::chrono::duration_cast<std::chrono::nanoseconds>(f * DEFAULT { 1 });
 
+			std::size_t end_pos = end - s.c_str();
 			for (const auto &m : match)
 			{
 				auto found = s.find(m.first, end_pos);

--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -34,10 +34,11 @@ public:
 
 		try
 		{
-			std::size_t end_pos;
-			float f = std::stof(s, &end_pos);
+			char *end;
+			float f = strtof_locale(s.c_str(), &end);
 			bps_ = f;
 
+			std::size_t end_pos = end - s.c_str();
 			for (const auto &m : match)
 			{
 				auto found = s.find(m.first, end_pos);


### PR DESCRIPTION
Some users have reported issues with the new TimeVal and Bitrate option types. This seems to be down to the local locale unable to interpret the command line argument string.

Fix this by using an explicit strtof_l() call and using the "C" locale to parse the string.