### PR TITLE
libav_encoder: Allow other libav encoders to be selected.

### DIFF
--- a/utils/test.py
+++ b/utils/test.py
@@ -387,6 +387,7 @@ def test_vid(exe_dir, output_dir):
     platform = get_platform()
     executable = os.path.join(exe_dir, 'rpicam-vid')
     output_h264 = os.path.join(output_dir, 'test.h264')
+    output_mkv = os.path.join(output_dir, 'test.mkv')
     output_mjpeg = os.path.join(output_dir, 'test.mjpeg')
     output_circular = os.path.join(output_dir, 'circular.h264')
     output_pause = os.path.join(output_dir, 'pause.h264')
@@ -405,6 +406,14 @@ def test_vid(exe_dir, output_dir):
     check_retcode(retcode, "test_vid: h264 test")
     check_time(time_taken, 2, 6, "test_vid: h264 test")
     check_size(output_h264, 1024, "test_vid: h264 test")
+
+    # "libav mkv test". See if the executable appears to run and write an mkv output file.
+    print("    libav mkv test")
+    retcode, time_taken = run_executable([executable, '-t', '2000', '-o', '--codec', 'libav', output_mkv],
+                                         logfile)
+    check_retcode(retcode, "test_vid: libav mkv test")
+    check_time(time_taken, 2, 6, "test_vid: libav mkv test")
+    check_size(output_mkv, 1024, "test_vid: libav mkv test")
 
     # "no-raw". As above, but with no raw stream
     print("    h264 test")


### PR DESCRIPTION
Add a general codec options function that will allow other libav encoders to be selected correctly.