### PR TITLE
rpicam_still: Fix immediate capture breakage

### DIFF
--- a/apps/rpicam_still.cpp
+++ b/apps/rpicam_still.cpp
@@ -211,7 +211,7 @@ static void event_loop(RPiCamStillApp &app)
 	} af_wait_state = AF_WAIT_NONE;
 	int af_wait_timeout = 0;
 
-	bool want_capture = false;
+	bool want_capture = options->immediate;
 	for (unsigned int count = 0;; count++)
 	{
 		RPiCamApp::Msg msg = app.Wait();

--- a/utils/test.py
+++ b/utils/test.py
@@ -232,6 +232,14 @@ def test_still(exe_dir, output_dir):
     check_time(time_taken, 1.2, 8, "test_still: zsl test")
     check_size(output_jpg, 1024, "test_still: zsl test")
 
+    # "immediate test". Immediate capture test
+    print("    immediate test")
+    retcode, time_taken = run_executable([executable, '-o', output_jpg, '--immediate', '--shutter', 20000,
+                                          '--gain', 1.0, '--awbgains', '1.5,1.2'], logfile)
+    check_retcode(retcode, "test_still: immediate test")
+    check_time(time_taken, 1.2, 8, "test_still: immediate test")
+    check_size(output_jpg, 1024, "test_still: immediate test")
+
     # "png test". As above, but write a png.
     print("    png test")
     retcode, time_taken = run_executable(


### PR DESCRIPTION
This feature was broken when adding the zsl option, fix it. Add a regression test for the immediate option as well.