### PR TITLE
libav codec options

### DIFF
--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -89,11 +89,11 @@ struct VideoOptions : public Options
 			("bitrate,b", value<std::string>(&bitrate_)->default_value("0bps"),
 			 "Set the video bitrate for encoding. If no units are provided, default to bits/second.")
 			("profile", value<std::string>(&profile),
-			 "Set the encoding profile (h264 only)")
+			 "Set the encoding profile")
 			("level", value<std::string>(&level),
-			 "Set the encoding level (h264 only)")
+			 "Set the encoding level")
 			("intra,g", value<unsigned int>(&intra)->default_value(0),
-			 "Set the intra frame period (h264 only)")
+			 "Set the intra frame period")
 			("inline", value<bool>(&inline_headers)->default_value(false)->implicit_value(true),
 			 "Force PPS/SPS header with every I frame (h264 only)")
 			("codec", value<std::string>(&codec)->default_value("h264"),
@@ -126,6 +126,12 @@ struct VideoOptions : public Options
 			("libav-video-codec", value<std::string>(&libav_video_codec)->default_value("h264_v4l2m2m"),
 			 "Sets the libav video codec to use. "
 			 "To list available codecs, run  the \"ffmpeg -codecs\" command.")
+			("libav-video-codec-opts", value<std::string>(&libav_video_codec_opts),
+			 "Sets the libav video codec options to use. "
+			 "These override the internal defaults (check 'encoderOptions*()' in 'encoder/libav_encoder.cpp' for the defaults). "
+			 "Separate key and value with \"=\" and multiple options with \";\". "
+			 "e.g.: \"preset=ultrafast;profile=high;partitions=i8x8,i4x4\". "
+			 "To list available options for a given codec, run the \"ffmpeg -h encoder=libx264\" command for libx264.")
 			("libav-format", value<std::string>(&libav_format),
 			 "Sets the libav encoder output format to use. "
 			 "Leave blank to try and deduce this from the filename.\n"
@@ -164,6 +170,7 @@ struct VideoOptions : public Options
 	bool inline_headers;
 	std::string codec;
 	std::string libav_video_codec;
+	std::string libav_video_codec_opts;
 	std::string libav_format;
 	bool libav_audio;
 	std::string audio_codec;
@@ -222,7 +229,7 @@ struct VideoOptions : public Options
 
 		// From https://en.wikipedia.org/wiki/Advanced_Video_Coding#Levels
 		double mbps = ((width + 15) >> 4) * ((height + 15) >> 4) * framerate.value_or(DEFAULT_FRAMERATE);
-		if ((codec == "h264" || codec == "libav") && mbps > 245760.0)
+		if ((codec == "h264" || (codec == "libav" && libav_video_codec == "libx264")) && mbps > 245760.0)
 		{
 			LOG(1, "Overriding H.264 level 4.2");
 			level = "4.2";

--- a/utils/test.py
+++ b/utils/test.py
@@ -432,6 +432,15 @@ def test_vid(exe_dir, output_dir):
     check_time(time_taken, 2, 6, "test_vid: libav libx264 mp4 test")
     check_size(output_mp4, 1024, "test_vid: libav libx264 mp4 test")
 
+    # "libav x264 options test". See if the executable appears to run and write an h264 output file with codec options.
+    print("    libav libx264 options test")
+    retcode, time_taken = run_executable([executable, '-t', '2000', '-o', output_h264, '--codec', 'libav',
+                                          '--libav-video-codec', 'libx264',
+                                          '--libav-video-codec-opts', 'preset=ultrafast;profile=high;partitions=i8x8,i4x4'], logfile)
+    check_retcode(retcode, "test_vid: libav libx264 options test")
+    check_time(time_taken, 2, 6, "test_vid: libav libx264 options test")
+    check_size(output_h264, 1024, "test_vid: libav libx264 options test")
+
     # "mjpeg test". As above, but write an mjpeg file.
     print("    mjpeg test")
     retcode, time_taken = run_executable([executable, '-t', '2000', '--codec', 'mjpeg',


### PR DESCRIPTION
This feature allows for specifying libav codec options.

AV1 encoding example with maximum encoding speed and low_latency on:
```
libcamera-vid -t 10000 --width 1280 --height 720 --framerate 30 --codec libav --libav-video-codec librav1e --libav-video-codec-opts "speed=10;rav1e-params=low_latency=true" -o video.webm
```
HEVC encoding example with ultrafast preset and main profile:
```
libcamera-vid -t 10000 --width 1280 --height 720 --framerate 30 --codec libav --libav-video-codec libx265 --libav-video-codec-opts "profile=main;preset=ultrafast" -o video.ts
```
H264 encoding example with the ultrafast preset, high profile and level 4.2:
```
libcamera-vid -t 10000 --width 1280 --height 720 --framerate 30 --codec libav --libav-video-codec libx264 --libav-video-codec-opts "preset=ultrafast;profile=high;level=4.2" -o video.ts
```

I've moved `encoderOptionsGeneral()` under the specific encoder settings so that they can be overridden on the command line.