### PR TITLE
libav_encoder: Fix missing codec profiles for some codecs

### DIFF
--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -28,13 +28,12 @@ void encoderOptionsGeneral(VideoOptions const *options, AVCodecContext *codec)
 
 	if (!options->profile.empty())
 	{
-		const AVCodec *encoder_codec = avcodec_find_encoder_by_name(options->libav_video_codec.c_str());
-		for (const AVProfile *encoder_profile = encoder_codec->profiles;
-			 encoder_profile && encoder_profile->profile != FF_PROFILE_UNKNOWN; encoder_profile++)
+		const AVCodecDescriptor *desc = avcodec_descriptor_get(codec->codec_id);
+		for (const AVProfile *profile = desc->profiles; profile && profile->profile != FF_PROFILE_UNKNOWN; profile++)
 		{
-			if (!strncasecmp(options->profile.c_str(), encoder_profile->name, options->profile.size()))
+			if (!strncasecmp(options->profile.c_str(), profile->name, options->profile.size()))
 			{
-				codec->profile = encoder_profile->profile;
+				codec->profile = profile->profile;
 				break;
 			}
 		}

--- a/encoder/libav_encoder.hpp
+++ b/encoder/libav_encoder.hpp
@@ -17,6 +17,7 @@
 extern "C"
 {
 #include "libavcodec/avcodec.h"
+#include "libavcodec/codec_desc.h"
 #include "libavdevice/avdevice.h"
 #include "libavformat/avformat.h"
 #include "libavutil/audio_fifo.h"


### PR DESCRIPTION
Some codecs do not seem to expose the profile array through AVCodec::profiles. Use the AVCodecDescriptor instead which seems to always be correct.