### PR TITLE
Pass app to BufferReadSync by reference

### DIFF
--- a/apps/rpicam_detect.cpp
+++ b/apps/rpicam_detect.cpp
@@ -107,7 +107,7 @@ static void event_loop(RPiCamDetectApp &app)
 
 			StreamInfo info;
 			libcamera::Stream *stream = app.StillStream(&info);
-			BufferReadSync r(app, completed_request->buffers[stream]);
+			BufferReadSync r(&app, completed_request->buffers[stream]);
 			const std::vector<libcamera::Span<uint8_t>> mem = r.Get();
 
 			// Generate a filename for the output and save it.


### PR DESCRIPTION
rpicam-detect fails to build.

![image](https://github.com/raspberrypi/rpicam-apps/assets/51314385/65474b97-92d2-499c-bae6-1069bf27f22a)

The app parameter should be passed by reference.