### PR TITLE
encoder: output: Fix bug where network output was not routed through …

### DIFF
--- a/apps/rpicam_raw.cpp
+++ b/apps/rpicam_raw.cpp
@@ -79,6 +79,8 @@ int main(int argc, char *argv[])
 		VideoOptions *options = app.GetOptions();
 		if (options->Parse(argc, argv))
 		{
+			// Disable any codec (h.264/libav) based operations.
+			options->codec = "yuv420";
 			options->denoise = "cdn_off";
 			options->nopreview = true;
 			if (options->verbose >= 2)

--- a/output/output.cpp
+++ b/output/output.cpp
@@ -13,6 +13,8 @@
 #include "net_output.hpp"
 #include "output.hpp"
 
+extern bool bcm2835_encoder_available();
+
 Output::Output(VideoOptions const *options)
 	: options_(options), fp_timestamps_(nullptr), state_(WAITING_KEYFRAME), time_offset_(0), last_timestamp_(0),
 	  buf_metadata_(std::cout.rdbuf()), of_metadata_()
@@ -101,7 +103,7 @@ void Output::outputBuffer(void *mem, size_t size, int64_t timestamp_us, uint32_t
 
 Output *Output::Create(VideoOptions const *options)
 {
-	if (options->codec == "libav")
+	if (options->codec == "libav" || (options->codec == "h264" && !bcm2835_encoder_available()))
 		return new Output(options);
 
 	if (strncmp(options->output.c_str(), "udp://", 6) == 0 || strncmp(options->output.c_str(), "tcp://", 6) == 0)


### PR DESCRIPTION
…libav on Pi 5

If the --codec libav option is not set, and a network stream output is specified, the NetOutput class will be initialised together with libav and fail to work on a Pi 5.

Fix this by ensuring if we are going to use libav, do not initialise the NetOutput class, and allow libav to handle the network output.