### PR TITLE
core: app: Extend the search for compatible video devices

### DIFF
--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -38,7 +38,7 @@ enum class Platform
 Platform get_platform()
 {
 	bool unknown = false;
-	for (unsigned int device_num = 0; device_num < 5; device_num++)
+	for (unsigned int device_num = 0; device_num < 256; device_num++)
 	{
 		char device_name[16];
 		snprintf(device_name, sizeof(device_name), "/dev/video%u", device_num);


### PR DESCRIPTION
In get_platform(), don't assume that a compatible video device will be found at /dev/video[0-4]. Extending the search range to /dev/video255 is cost-free in cases where it terminates early.