### PR TITLE
core: Deprecate properties::ScalerCropMaximum

### DIFF
--- a/core/options.cpp
+++ b/core/options.cpp
@@ -302,10 +302,10 @@ bool Options::Parse(int argc, char *argv[])
 						}
 
 						auto fd_ctrl = cam->controls().find(&controls::FrameDurationLimits);
-						auto crop_ctrl = cam->properties().get(properties::ScalerCropMaximum);
+						auto crop_ctrl = cam->controls().at(&controls::ScalerCrop).max().get<Rectangle>();
 						double fps = fd_ctrl == cam->controls().end() ? NAN : (1e6 / fd_ctrl->second.min().get<int64_t>());
 						std::cout << std::fixed << std::setprecision(2) << "["
-								  << fps << " fps - " << crop_ctrl->toString() << " crop" << "]";
+								  << fps << " fps - " << crop_ctrl.toString() << " crop" << "]";
 						if (--num)
 						{
 							std::cout << std::endl;

--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -680,7 +680,7 @@ void RPiCamApp::StartCamera()
 	// We don't overwrite anything the application may have set before calling us.
 	if (!controls_.get(controls::ScalerCrop) && options_->roi_width != 0 && options_->roi_height != 0)
 	{
-		Rectangle sensor_area = *camera_->properties().get(properties::ScalerCropMaximum);
+		Rectangle sensor_area = camera_->controls().at(&controls::ScalerCrop).max().get<Rectangle>();
 		int x = options_->roi_x * sensor_area.width;
 		int y = options_->roi_y * sensor_area.height;
 		int w = options_->roi_width * sensor_area.width;
@@ -694,7 +694,7 @@ void RPiCamApp::StartCamera()
 	if (!controls_.get(controls::AfWindows) && !controls_.get(controls::AfMetering) && options_->afWindow_width != 0 &&
 		options_->afWindow_height != 0)
 	{
-		Rectangle sensor_area = *camera_->properties().get(properties::ScalerCropMaximum);
+		Rectangle sensor_area = camera_->controls().at(&controls::ScalerCrop).max().get<Rectangle>();
 		int x = options_->afWindow_x * sensor_area.width;
 		int y = options_->afWindow_y * sensor_area.height;
 		int w = options_->afWindow_width * sensor_area.width;


### PR DESCRIPTION
This property will be removed from libcamera soon.  Replace it with the maximum value of controls::ScalerCrop, which the pipeline handler sets to the same rectangle.