### PR TITLE
libav: Warn on using options that don't work with the libav encoder

### DIFF
--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -332,6 +332,10 @@ LibAvEncoder::LibAvEncoder(VideoOptions const *options, StreamInfo const &info)
 	: Encoder(options), output_ready_(false), abort_video_(false), abort_audio_(false), video_start_ts_(0),
 	  audio_samples_(0), in_fmt_ctx_(nullptr), out_fmt_ctx_(nullptr), output_file_(options->output)
 {
+	if (options->circular || options->segment || !options->save_pts.empty() || options->split)
+		LOG_ERROR("\nERROR: Pi 5 and libav encoder does not currently support the circular, segment, save_pts or "
+				  "split command line options, they will be ignored!\n");
+
 	avdevice_register_all();
 
 	if (options->verbose >= 2)


### PR DESCRIPTION
The circular, segment, save_pts and split functions don't work when using the libav encoder.  Loudly warn if the user tries to use one of these options.