### PR TITLE
encoder: pass VIDIOC_QUERYCAP as unsigned long

### DIFF
--- a/encoder/encoder.cpp
+++ b/encoder/encoder.cpp
@@ -25,11 +25,12 @@ bool bcm2835_encoder_available()
 {
 	const char hw_codec[] = "/dev/video11";
 	struct v4l2_capability caps;
+	unsigned long request = VIDIOC_QUERYCAP;
 	memset(&caps, 0, sizeof(caps));
 	int fd = open(hw_codec, O_RDWR, 0);
 	if (fd)
 	{
-		int ret = ioctl(fd, VIDIOC_QUERYCAP, &caps);
+		int ret = ioctl(fd, request, &caps);
 		close(fd);
 		if (!ret && !strncmp((char *)caps.card, "bcm2835-codec-encode", sizeof(caps.card)))
 			return true;


### PR DESCRIPTION
VIDIOC_QUARYCAP is an unsigned long and should be passed as one.

Get rid of the following error:
encoder/encoder.cpp:32:37: error: overflow in conversion from 'long unsigned int' to 'int' changes value from '2154321408' to '-2140645888' [-Werror=overflow]
   32 |                 int ret = ioctl(fd, VIDIOC_QUERYCAP, &caps);