### PR TITLE
options: Add GetPlatform() helper

### DIFF
--- a/core/options.cpp
+++ b/core/options.cpp
@@ -129,6 +129,173 @@ static bool set_subdev_hdr_ctrl(int en)
 	return changed;
 }
 
+
+Platform get_platform()
+{
+	bool unknown = false;
+	for (unsigned int device_num = 0; device_num < 256; device_num++)
+	{
+		char device_name[16];
+		snprintf(device_name, sizeof(device_name), "/dev/video%u", device_num);
+		int fd = open(device_name, O_RDWR, 0);
+		if (fd < 0)
+			continue;
+
+		v4l2_capability caps;
+		unsigned long request = VIDIOC_QUERYCAP;
+
+		int ret = ioctl(fd, request, &caps);
+		close(fd);
+
+		if (ret)
+			continue;
+
+		// We are not concerned with UVC devices for now.
+		if (!strncmp((char *)caps.driver, "uvcvideo", sizeof(caps.card)))
+			continue;
+
+		if (!strncmp((char *)caps.card, "bcm2835-isp", sizeof(caps.card)))
+			return Platform::VC4;
+		else if (!strncmp((char *)caps.card, "pispbe", sizeof(caps.card)))
+			return Platform::PISP;
+		else if (!strncmp((char *)caps.card, "bm2835 mmal", sizeof(caps.card)))
+			return Platform::LEGACY;
+		else
+			unknown = true;
+	}
+
+	return unknown ? Platform::UNKNOWN : Platform::MISSING;
+}
+
+Options::Options()
+	: set_default_lens_position(false), af_on_capture(false), options_("Valid options are", 120, 80), app_(nullptr)
+{
+	using namespace boost::program_options;
+
+	// clang-format off
+	options_.add_options()
+		("help,h", value<bool>(&help)->default_value(false)->implicit_value(true),
+			"Print this help message")
+		("version", value<bool>(&version)->default_value(false)->implicit_value(true),
+			"Displays the build version number")
+		("list-cameras", value<bool>(&list_cameras)->default_value(false)->implicit_value(true),
+			"Lists the available cameras attached to the system.")
+		("camera", value<unsigned int>(&camera)->default_value(0),
+			"Chooses the camera to use. To list the available indexes, use the --list-cameras option.")
+		("verbose,v", value<unsigned int>(&verbose)->default_value(1)->implicit_value(2),
+			"Set verbosity level. Level 0 is no output, 1 is default, 2 is verbose.")
+		("config,c", value<std::string>(&config_file)->implicit_value("config.txt"),
+			"Read the options from a file. If no filename is specified, default to config.txt. "
+			"In case of duplicate options, the ones provided on the command line will be used. "
+			"Note that the config file must only contain the long form options.")
+		("info-text", value<std::string>(&info_text)->default_value("#%frame (%fps fps) exp %exp ag %ag dg %dg"),
+			"Sets the information string on the titlebar. Available values:\n"
+			"%frame (frame number)\n%fps (framerate)\n%exp (shutter speed)\n%ag (analogue gain)"
+			"\n%dg (digital gain)\n%rg (red colour gain)\n%bg (blue colour gain)"
+			"\n%focus (focus FoM value)\n%aelock (AE locked status)"
+			"\n%lp (lens position, if known)\n%afstate (AF state, if supported)")
+		("width", value<unsigned int>(&width)->default_value(0),
+			"Set the output image width (0 = use default value)")
+		("height", value<unsigned int>(&height)->default_value(0),
+			"Set the output image height (0 = use default value)")
+		("timeout,t", value<std::string>(&timeout_)->default_value("5sec"),
+			"Time for which program runs. If no units are provided default to ms.")
+		("output,o", value<std::string>(&output),
+			"Set the output file name")
+		("post-process-file", value<std::string>(&post_process_file),
+			"Set the file name for configuring the post-processing")
+		("nopreview,n", value<bool>(&nopreview)->default_value(false)->implicit_value(true),
+			"Do not show a preview window")
+		("preview,p", value<std::string>(&preview)->default_value("0,0,0,0"),
+			"Set the preview window dimensions, given as x,y,width,height e.g. 0,0,640,480")
+		("fullscreen,f", value<bool>(&fullscreen)->default_value(false)->implicit_value(true),
+			"Use a fullscreen preview window")
+		("qt-preview", value<bool>(&qt_preview)->default_value(false)->implicit_value(true),
+			"Use Qt-based preview window (WARNING: causes heavy CPU load, fullscreen not supported)")
+		("hflip", value<bool>(&hflip_)->default_value(false)->implicit_value(true), "Request a horizontal flip transform")
+		("vflip", value<bool>(&vflip_)->default_value(false)->implicit_value(true), "Request a vertical flip transform")
+		("rotation", value<int>(&rotation_)->default_value(0), "Request an image rotation, 0 or 180")
+		("roi", value<std::string>(&roi)->default_value("0,0,0,0"), "Set region of interest (digital zoom) e.g. 0.25,0.25,0.5,0.5")
+		("shutter", value<std::string>(&shutter_)->default_value("0"),
+			"Set a fixed shutter speed. If no units are provided default to us")
+		("analoggain", value<float>(&gain)->default_value(0),
+			"Set a fixed gain value (synonym for 'gain' option)")
+		("gain", value<float>(&gain),
+			"Set a fixed gain value")
+		("metering", value<std::string>(&metering)->default_value("centre"),
+			"Set the metering mode (centre, spot, average, custom)")
+		("exposure", value<std::string>(&exposure)->default_value("normal"),
+			"Set the exposure mode (normal, sport)")
+		("ev", value<float>(&ev)->default_value(0),
+			"Set the EV exposure compensation, where 0 = no change")
+		("awb", value<std::string>(&awb)->default_value("auto"),
+			"Set the AWB mode (auto, incandescent, tungsten, fluorescent, indoor, daylight, cloudy, custom)")
+		("awbgains", value<std::string>(&awbgains)->default_value("0,0"),
+			"Set explict red and blue gains (disable the automatic AWB algorithm)")
+		("flush", value<bool>(&flush)->default_value(false)->implicit_value(true),
+			"Flush output data as soon as possible")
+		("wrap", value<unsigned int>(&wrap)->default_value(0),
+			"When writing multiple output files, reset the counter when it reaches this number")
+		("brightness", value<float>(&brightness)->default_value(0),
+			"Adjust the brightness of the output images, in the range -1.0 to 1.0")
+		("contrast", value<float>(&contrast)->default_value(1.0),
+			"Adjust the contrast of the output image, where 1.0 = normal contrast")
+		("saturation", value<float>(&saturation)->default_value(1.0),
+			"Adjust the colour saturation of the output, where 1.0 = normal and 0.0 = greyscale")
+		("sharpness", value<float>(&sharpness)->default_value(1.0),
+			"Adjust the sharpness of the output image, where 1.0 = normal sharpening")
+		("framerate", value<float>(&framerate_)->default_value(-1.0),
+			"Set the fixed framerate for preview and video modes")
+		("denoise", value<std::string>(&denoise)->default_value("auto"),
+			"Sets the Denoise operating mode: auto, off, cdn_off, cdn_fast, cdn_hq")
+		("viewfinder-width", value<unsigned int>(&viewfinder_width)->default_value(0),
+			"Width of viewfinder frames from the camera (distinct from the preview window size")
+		("viewfinder-height", value<unsigned int>(&viewfinder_height)->default_value(0),
+			"Height of viewfinder frames from the camera (distinct from the preview window size)")
+		("tuning-file", value<std::string>(&tuning_file)->default_value("-"),
+			"Name of camera tuning file to use, omit this option for libcamera default behaviour")
+		("lores-width", value<unsigned int>(&lores_width)->default_value(0),
+			"Width of low resolution frames (use 0 to omit low resolution stream")
+		("lores-height", value<unsigned int>(&lores_height)->default_value(0),
+			"Height of low resolution frames (use 0 to omit low resolution stream")
+		("mode", value<std::string>(&mode_string),
+			"Camera mode as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
+		("viewfinder-mode", value<std::string>(&viewfinder_mode_string),
+			"Camera mode for preview as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
+		("buffer-count", value<unsigned int>(&buffer_count)->default_value(0), "Number of in-flight requests (and buffers) configured for video, raw, and still.")
+		("viewfinder-buffer-count", value<unsigned int>(&viewfinder_buffer_count)->default_value(0), "Number of in-flight requests (and buffers) configured for preview window.")
+		("no-raw", value<bool>(&no_raw)->default_value(false)->implicit_value(true),
+			"Disable requesting of a RAW stream. Will override any manual mode reqest the mode choice when setting framerate.")
+		("autofocus-mode", value<std::string>(&afMode)->default_value("default"),
+			"Control to set the mode of the AF (autofocus) algorithm.(manual, auto, continuous)")
+		("autofocus-range", value<std::string>(&afRange)->default_value("normal"),
+			"Set the range of focus distances that is scanned.(normal, macro, full)")
+		("autofocus-speed", value<std::string>(&afSpeed)->default_value("normal"),
+			"Control that determines whether the AF algorithm is to move the lens as quickly as possible or more steadily.(normal, fast)")
+		("autofocus-window", value<std::string>(&afWindow)->default_value("0,0,0,0"),
+		"Sets AfMetering to  AfMeteringWindows an set region used, e.g. 0.25,0.25,0.5,0.5")
+		("lens-position", value<std::string>(&lens_position_)->default_value(""),
+			"Set the lens to a particular focus position, expressed as a reciprocal distance (0 moves the lens to infinity), or \"default\" for the hyperfocal distance")
+		("hdr", value<std::string>(&hdr)->default_value("off")->implicit_value("auto"),
+			"Enable High Dynamic Range, where supported. Available values are \"off\", \"auto\", "
+			"\"sensor\" for sensor HDR (e.g. for Camera Module 3), "
+			"\"single-exp\" for PiSP based single exposure multiframe HDR")
+		("metadata", value<std::string>(&metadata),
+			"Save captured image metadata to a file or \"-\" for stdout")
+		("metadata-format", value<std::string>(&metadata_format)->default_value("json"),
+			"Format to save the metadata in, either txt or json (requires --metadata)")
+		("flicker-period", value<std::string>(&flicker_period_)->default_value("0s"),
+			"Manual flicker correction period"
+			"\nSet to 10000us to cancel 50Hz flicker."
+			"\nSet to 8333us to cancel 60Hz flicker.\n")
+		;
+	// clang-format on
+
+	// This is really the best place to cache the platform, all components
+	// in rpicam-apps get the options structure;
+	platform_ = get_platform();
+}
+
 bool Options::Parse(int argc, char *argv[])
 {
 	using namespace boost::program_options;

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -92,132 +92,18 @@ struct TimeVal
 	std::chrono::nanoseconds value;
 };
 
+enum class Platform
+{
+	MISSING,
+	UNKNOWN,
+	LEGACY,
+	VC4,
+	PISP,
+};
+
 struct Options
 {
-	Options()
-		: set_default_lens_position(false), af_on_capture(false), options_("Valid options are", 120, 80), app_(nullptr)
-	{
-		using namespace boost::program_options;
-		// clang-format off
-		options_.add_options()
-			("help,h", value<bool>(&help)->default_value(false)->implicit_value(true),
-			 "Print this help message")
-			("version", value<bool>(&version)->default_value(false)->implicit_value(true),
-			 "Displays the build version number")
-			("list-cameras", value<bool>(&list_cameras)->default_value(false)->implicit_value(true),
-			 "Lists the available cameras attached to the system.")
-			("camera", value<unsigned int>(&camera)->default_value(0),
-			 "Chooses the camera to use. To list the available indexes, use the --list-cameras option.")
-			("verbose,v", value<unsigned int>(&verbose)->default_value(1)->implicit_value(2),
-			 "Set verbosity level. Level 0 is no output, 1 is default, 2 is verbose.")
-			("config,c", value<std::string>(&config_file)->implicit_value("config.txt"),
-			 "Read the options from a file. If no filename is specified, default to config.txt. "
-			 "In case of duplicate options, the ones provided on the command line will be used. "
-			 "Note that the config file must only contain the long form options.")
-			("info-text", value<std::string>(&info_text)->default_value("#%frame (%fps fps) exp %exp ag %ag dg %dg"),
-			 "Sets the information string on the titlebar. Available values:\n"
-			 "%frame (frame number)\n%fps (framerate)\n%exp (shutter speed)\n%ag (analogue gain)"
-			 "\n%dg (digital gain)\n%rg (red colour gain)\n%bg (blue colour gain)"
-			 "\n%focus (focus FoM value)\n%aelock (AE locked status)"
-			 "\n%lp (lens position, if known)\n%afstate (AF state, if supported)")
-			("width", value<unsigned int>(&width)->default_value(0),
-			 "Set the output image width (0 = use default value)")
-			("height", value<unsigned int>(&height)->default_value(0),
-			 "Set the output image height (0 = use default value)")
-			("timeout,t", value<std::string>(&timeout_)->default_value("5sec"),
-			 "Time for which program runs. If no units are provided default to ms.")
-			("output,o", value<std::string>(&output),
-			 "Set the output file name")
-			("post-process-file", value<std::string>(&post_process_file),
-			 "Set the file name for configuring the post-processing")
-			("nopreview,n", value<bool>(&nopreview)->default_value(false)->implicit_value(true),
-			 "Do not show a preview window")
-			("preview,p", value<std::string>(&preview)->default_value("0,0,0,0"),
-			 "Set the preview window dimensions, given as x,y,width,height e.g. 0,0,640,480")
-			("fullscreen,f", value<bool>(&fullscreen)->default_value(false)->implicit_value(true),
-			 "Use a fullscreen preview window")
-			("qt-preview", value<bool>(&qt_preview)->default_value(false)->implicit_value(true),
-			 "Use Qt-based preview window (WARNING: causes heavy CPU load, fullscreen not supported)")
-			("hflip", value<bool>(&hflip_)->default_value(false)->implicit_value(true), "Request a horizontal flip transform")
-			("vflip", value<bool>(&vflip_)->default_value(false)->implicit_value(true), "Request a vertical flip transform")
-			("rotation", value<int>(&rotation_)->default_value(0), "Request an image rotation, 0 or 180")
-			("roi", value<std::string>(&roi)->default_value("0,0,0,0"), "Set region of interest (digital zoom) e.g. 0.25,0.25,0.5,0.5")
-			("shutter", value<std::string>(&shutter_)->default_value("0"),
-			 "Set a fixed shutter speed. If no units are provided default to us")
-			("analoggain", value<float>(&gain)->default_value(0),
-			 "Set a fixed gain value (synonym for 'gain' option)")
-			("gain", value<float>(&gain),
-			 "Set a fixed gain value")
-			("metering", value<std::string>(&metering)->default_value("centre"),
-			 "Set the metering mode (centre, spot, average, custom)")
-			("exposure", value<std::string>(&exposure)->default_value("normal"),
-			 "Set the exposure mode (normal, sport)")
-			("ev", value<float>(&ev)->default_value(0),
-			 "Set the EV exposure compensation, where 0 = no change")
-			("awb", value<std::string>(&awb)->default_value("auto"),
-			 "Set the AWB mode (auto, incandescent, tungsten, fluorescent, indoor, daylight, cloudy, custom)")
-			("awbgains", value<std::string>(&awbgains)->default_value("0,0"),
-			 "Set explict red and blue gains (disable the automatic AWB algorithm)")
-			("flush", value<bool>(&flush)->default_value(false)->implicit_value(true),
-			 "Flush output data as soon as possible")
-			("wrap", value<unsigned int>(&wrap)->default_value(0),
-			 "When writing multiple output files, reset the counter when it reaches this number")
-			("brightness", value<float>(&brightness)->default_value(0),
-			 "Adjust the brightness of the output images, in the range -1.0 to 1.0")
-			("contrast", value<float>(&contrast)->default_value(1.0),
-			 "Adjust the contrast of the output image, where 1.0 = normal contrast")
-			("saturation", value<float>(&saturation)->default_value(1.0),
-			 "Adjust the colour saturation of the output, where 1.0 = normal and 0.0 = greyscale")
-			("sharpness", value<float>(&sharpness)->default_value(1.0),
-			 "Adjust the sharpness of the output image, where 1.0 = normal sharpening")
-			("framerate", value<float>(&framerate_)->default_value(-1.0),
-			 "Set the fixed framerate for preview and video modes")
-			("denoise", value<std::string>(&denoise)->default_value("auto"),
-			 "Sets the Denoise operating mode: auto, off, cdn_off, cdn_fast, cdn_hq")
-			("viewfinder-width", value<unsigned int>(&viewfinder_width)->default_value(0),
-			 "Width of viewfinder frames from the camera (distinct from the preview window size")
-			("viewfinder-height", value<unsigned int>(&viewfinder_height)->default_value(0),
-			 "Height of viewfinder frames from the camera (distinct from the preview window size)")
-			("tuning-file", value<std::string>(&tuning_file)->default_value("-"),
-			 "Name of camera tuning file to use, omit this option for libcamera default behaviour")
-			("lores-width", value<unsigned int>(&lores_width)->default_value(0),
-			 "Width of low resolution frames (use 0 to omit low resolution stream")
-			("lores-height", value<unsigned int>(&lores_height)->default_value(0),
-			 "Height of low resolution frames (use 0 to omit low resolution stream")
-			("mode", value<std::string>(&mode_string),
-			 "Camera mode as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
-			("viewfinder-mode", value<std::string>(&viewfinder_mode_string),
-			 "Camera mode for preview as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
-			("buffer-count", value<unsigned int>(&buffer_count)->default_value(0), "Number of in-flight requests (and buffers) configured for video, raw, and still.")
-			("viewfinder-buffer-count", value<unsigned int>(&viewfinder_buffer_count)->default_value(0), "Number of in-flight requests (and buffers) configured for preview window.")
-			("no-raw", value<bool>(&no_raw)->default_value(false)->implicit_value(true),
-			 "Disable requesting of a RAW stream. Will override any manual mode reqest the mode choice when setting framerate.")
-			("autofocus-mode", value<std::string>(&afMode)->default_value("default"),
-			 "Control to set the mode of the AF (autofocus) algorithm.(manual, auto, continuous)")
-			("autofocus-range", value<std::string>(&afRange)->default_value("normal"),
-			 "Set the range of focus distances that is scanned.(normal, macro, full)")
-			("autofocus-speed", value<std::string>(&afSpeed)->default_value("normal"),
-			 "Control that determines whether the AF algorithm is to move the lens as quickly as possible or more steadily.(normal, fast)")
-			("autofocus-window", value<std::string>(&afWindow)->default_value("0,0,0,0"),
-			"Sets AfMetering to  AfMeteringWindows an set region used, e.g. 0.25,0.25,0.5,0.5")
-			("lens-position", value<std::string>(&lens_position_)->default_value(""),
-			 "Set the lens to a particular focus position, expressed as a reciprocal distance (0 moves the lens to infinity), or \"default\" for the hyperfocal distance")
-			("hdr", value<std::string>(&hdr)->default_value("off")->implicit_value("auto"),
-			 "Enable High Dynamic Range, where supported. Available values are \"off\", \"auto\", "
-			 "\"sensor\" for sensor HDR (e.g. for Camera Module 3), "
-			 "\"single-exp\" for PiSP based single exposure multiframe HDR")
-			("metadata", value<std::string>(&metadata),
-			 "Save captured image metadata to a file or \"-\" for stdout")
-			("metadata-format", value<std::string>(&metadata_format)->default_value("json"),
-			 "Format to save the metadata in, either txt or json (requires --metadata)")
-			("flicker-period", value<std::string>(&flicker_period_)->default_value("0s"),
-			 "Manual flicker correction period"
-			 "\nSet to 10000us to cancel 50Hz flicker."
-			 "\nSet to 8333us to cancel 60Hz flicker.\n")
-			;
-		// clang-format on
-	}
-
+	Options();
 	virtual ~Options() {}
 
 	bool help;
@@ -292,6 +178,7 @@ struct Options
 	virtual void Print() const;
 
 	void SetApp(RPiCamApp *app) { app_ = app; }
+	Platform GetPlatform() const { return platform_; };
 
 protected:
 	boost::program_options::options_description options_;
@@ -306,4 +193,5 @@ private:
 	std::string shutter_;
 	std::string flicker_period_;
 	RPiCamApp *app_;
+	Platform platform_ = Platform::UNKNOWN;
 };

--- a/encoder/encoder.cpp
+++ b/encoder/encoder.cpp
@@ -21,26 +21,9 @@
 #include "libav_encoder.hpp"
 #endif
 
-bool bcm2835_encoder_available()
-{
-	const char hw_codec[] = "/dev/video11";
-	struct v4l2_capability caps;
-	unsigned long request = VIDIOC_QUERYCAP;
-	memset(&caps, 0, sizeof(caps));
-	int fd = open(hw_codec, O_RDWR, 0);
-	if (fd)
-	{
-		int ret = ioctl(fd, request, &caps);
-		close(fd);
-		if (!ret && !strncmp((char *)caps.card, "bcm2835-codec-encode", sizeof(caps.card)))
-			return true;
-	}
-	return false;
-}
-
 static Encoder *h264_codec_select(VideoOptions *options, const StreamInfo &info)
 {
-	if (bcm2835_encoder_available())
+	if (options->GetPlatform() == Platform::VC4)
 		return new H264Encoder(options, info);
 
 #if LIBAV_PRESENT
@@ -57,7 +40,7 @@ static Encoder *libav_codec_select(VideoOptions *options, const StreamInfo &info
 {
 	if (options->libav_video_codec == "h264_v4l2m2m")
 	{
-		if (bcm2835_encoder_available())
+		if (options->GetPlatform() == Platform::VC4)
 				return new LibAvEncoder(options, info);
 		// No h264_v4l2m2m libav codec available, use libx264 if nothing else is provided.
 		options->libav_video_codec = "libx264";

--- a/output/output.cpp
+++ b/output/output.cpp
@@ -13,8 +13,6 @@
 #include "net_output.hpp"
 #include "output.hpp"
 
-extern bool bcm2835_encoder_available();
-
 Output::Output(VideoOptions const *options)
 	: options_(options), fp_timestamps_(nullptr), state_(WAITING_KEYFRAME), time_offset_(0), last_timestamp_(0),
 	  buf_metadata_(std::cout.rdbuf()), of_metadata_()
@@ -103,7 +101,7 @@ void Output::outputBuffer(void *mem, size_t size, int64_t timestamp_us, uint32_t
 
 Output *Output::Create(VideoOptions const *options)
 {
-	if (options->codec == "libav" || (options->codec == "h264" && !bcm2835_encoder_available()))
+	if (options->codec == "libav" || (options->codec == "h264" && options->GetPlatform() != Platform::VC4))
 		return new Output(options);
 
 	if (strncmp(options->output.c_str(), "udp://", 6) == 0 || strncmp(options->output.c_str(), "tcp://", 6) == 0)


### PR DESCRIPTION
Add a helper to get the platform identifier to the options class. This is the most convenient place for the helper as all rpicam-apps components get the options pass into it.