### PR TITLE
core: Use CompletedRequestPtr in the FrameInfo constructor

### DIFF
--- a/apps/rpicam_still.cpp
+++ b/apps/rpicam_still.cpp
@@ -252,7 +252,7 @@ static void event_loop(RPiCamStillApp &app)
 
 			if (af_wait_state != AF_WAIT_NONE)
 			{
-				FrameInfo fi(completed_request->metadata);
+				FrameInfo fi(completed_request);
 				bool scanning = fi.af_state == libcamera::controls::AfStateScanning;
 				if (scanning || (af_wait_state == AF_WAIT_SCANNING && ++af_wait_timeout >= 16))
 					af_wait_state = AF_WAIT_FINISHED;

--- a/core/frame_info.hpp
+++ b/core/frame_info.hpp
@@ -12,12 +12,19 @@
 #include <libcamera/control_ids.h>
 #include <libcamera/controls.h>
 
+#include "completed_request.hpp"
+
 struct FrameInfo
 {
-	FrameInfo(libcamera::ControlList &ctrls)
+	FrameInfo(const CompletedRequestPtr &completed_request)
 		: exposure_time(0.0), digital_gain(0.0), colour_gains({ { 0.0f, 0.0f } }), focus(0.0), aelock(false),
 		  lens_position(-1.0), af_state(0)
 	{
+		const libcamera::ControlList &ctrls = completed_request->metadata;
+
+		sequence = completed_request->sequence;
+		fps = completed_request->framerate;
+
 		auto exp = ctrls.get(libcamera::controls::ExposureTime);
 		if (exp)
 			exposure_time = *exp;
@@ -53,7 +60,7 @@ struct FrameInfo
 			af_state = *afs;
 	}
 
-	std::string ToString(std::string &info_string) const
+	std::string ToString(const std::string &info_string) const
 	{
 		std::string parsed(info_string);
 

--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -1154,9 +1154,7 @@ void RPiCamApp::previewThread()
 		libcamera::Span span = r.Get()[0];
 
 		// Fill the frame info with the ControlList items and ancillary bits.
-		FrameInfo frame_info(item.completed_request->metadata);
-		frame_info.fps = item.completed_request->framerate;
-		frame_info.sequence = item.completed_request->sequence;
+		FrameInfo frame_info(item.completed_request);
 
 		int fd = buffer->planes()[0].fd.get();
 		{

--- a/post_processing_stages/annotate_cv_stage.cpp
+++ b/post_processing_stages/annotate_cv_stage.cpp
@@ -84,8 +84,7 @@ bool AnnotateCvStage::Process(CompletedRequestPtr &completed_request)
 {
 	BufferWriteSync w(app_, completed_request->buffers[stream_]);
 	libcamera::Span<uint8_t> buffer = w.Get()[0];
-	FrameInfo info(completed_request->metadata);
-	info.sequence = completed_request->sequence;
+	FrameInfo info(completed_request);
 
 	// Other post-processing stages can supply metadata to update the text.
 	completed_request->post_process_metadata.Get("annotate.text", text_);


### PR DESCRIPTION
This allows the constructor to set fps and sequence directly rather than having to do it outside of the class. Fixes the annotate stage where we don't set the fps field.