### PR TITLE
[draft] Selective Recording based on object detection, detection log

### DIFF
--- a/apps/rpicam_jpeg.cpp
+++ b/apps/rpicam_jpeg.cpp
@@ -27,6 +27,9 @@ public:
 	{
 		return static_cast<StillOptions *>(options_.get());
 	}
+
+	void StartRecording() {};
+	void StopRecording() {};
 };
 
 // The main even loop for the application.

--- a/apps/rpicam_still.cpp
+++ b/apps/rpicam_still.cpp
@@ -28,6 +28,8 @@ class RPiCamStillApp : public RPiCamApp
 {
 public:
 	RPiCamStillApp() : RPiCamApp(std::make_unique<StillOptions>()) {}
+	void StartRecording() {};
+	void StopRecording() {};
 
 	StillOptions *GetOptions() const { return static_cast<StillOptions *>(options_.get()); }
 };

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -102,8 +102,9 @@ static void event_loop(RPiCamEncoder &app)
 		int key = get_key_or_signal(options, p);
 		// if (key == '\n')
 		//	output->Signal();
-		if (key == '\n')  // For example, if Enter key is pressed
+		if (key == 'r')  // For example, if Enter key is pressed
 		{
+			std::cout << "Recording key pressed" << std::endl;
 			if (app.IsRecording())
 				app.StopRecording();
 			else

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -75,7 +75,7 @@ static void event_loop(RPiCamEncoder &app)
 	app.ConfigureVideo(get_colourspace_flags(options->codec));
 	app.StartEncoder();
 	app.StartCamera();
-	auto start_time = std::chrono::high_resolution_clock::now();
+	auto start_time = std::chrono::steady_clock::now();
 
 	// Monitoring for keypresses and signals.
 	signal(SIGUSR1, default_signal_handler);
@@ -122,7 +122,6 @@ static void event_loop(RPiCamEncoder &app)
 		}
 
 		LOG(2, "Viewfinder frame " << count);
-		auto now = std::chrono::high_resolution_clock::now();
 		bool timeout = !options->frames && options->timeout &&
 					   ((now - start_time) > options->timeout.value);
 		bool frameout = options->frames && count >= options->frames;

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -104,7 +104,7 @@ static void event_loop(RPiCamEncoder &app)
 		//	output->Signal();
 		if (key == '\n')  // For example, if Enter key is pressed
 		{
-			if (app.is_recording_)
+			if (app.isRecording())
 				app.StopRecording();
 			else
 				app.StartRecording();  // No need to provide a filename

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -87,7 +87,7 @@ static void event_loop(RPiCamEncoder &app)
 	signal(SIGPIPE, default_signal_handler);
 	pollfd p[1] = { { STDIN_FILENO, POLLIN, 0 } };
 
-	RecordingManager::getInstance().setPostDetectionRecordTime(30);
+	RecordingManager::getInstance().setPostDetectionRecordTime(5);
 
 	for (unsigned int count = 0; ; count++)
 	{

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -87,8 +87,6 @@ static void event_loop(RPiCamEncoder &app)
 	signal(SIGPIPE, default_signal_handler);
 	pollfd p[1] = { { STDIN_FILENO, POLLIN, 0 } };
 
-	RecordingManager::getInstance().setPostDetectionRecordTime(5);
-
 	for (unsigned int count = 0; ; count++)
 	{
 		RPiCamEncoder::Msg msg = app.Wait();
@@ -150,7 +148,7 @@ int main(int argc, char *argv[])
 		{
 			if (options->verbose >= 2)
 				options->Print();
-
+			RecordingManager::getInstance().setPostDetectionRecordTime(options->record_detection);
 			event_loop(app);
 		}
 	}

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -100,8 +100,15 @@ static void event_loop(RPiCamEncoder &app)
 		else if (msg.type != RPiCamEncoder::MsgType::RequestComplete)
 			throw std::runtime_error("unrecognised message!");
 		int key = get_key_or_signal(options, p);
-		if (key == '\n')
-			output->Signal();
+		// if (key == '\n')
+		//	output->Signal();
+		if (key == '\n')  // For example, if Enter key is pressed
+		{
+			if (app.is_recording_)
+				app.StopRecording();
+			else
+				app.StartRecording();  // No need to provide a filename
+		}
 
 		LOG(2, "Viewfinder frame " << count);
 		auto now = std::chrono::high_resolution_clock::now();

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -112,12 +112,12 @@ static void event_loop(RPiCamEncoder &app)
         if (should_record && !app.IsRecording())
 		{
 			app.StartRecording();
-			std::cout << "Recording started" << std::endl;
+			std::cout << "Recording started called at least" << std::endl;
 		}
 		else if (!should_record && app.IsRecording())
 		{
 			app.StopRecording();
-			std::cout << "Recording stopped" << std::endl;
+			std::cout << "Recording stopped called at least" << std::endl;
 		}
 
 		LOG(2, "Viewfinder frame " << count);

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -65,7 +65,6 @@ static int get_colourspace_flags(std::string const &codec)
 
 static void event_loop(RPiCamEncoder &app)
 {
-	auto last_toggle = std::chrono::steady_clock::now();
 	const auto toggle_interval = std::chrono::seconds(10);
 	VideoOptions const *options = app.GetOptions();
 	std::unique_ptr<Output> output = std::unique_ptr<Output>(Output::Create(options));
@@ -108,6 +107,7 @@ static void event_loop(RPiCamEncoder &app)
 		if (key == '\n')
 			output->Signal();
 
+                auto now = std::chrono::steady_clock::now();
 		bool should_record = RecordingManager::getInstance().shouldRecord();
         if (should_record && !app.IsRecording())
 		{

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -108,16 +108,9 @@ static void event_loop(RPiCamEncoder &app)
 		auto now = std::chrono::steady_clock::now();
 		if (now - last_toggle >= toggle_interval)
 		{
-			if (app.IsRecording())
-			{
-				app.StopRecording();
-				std::cout << "Recording stopped" << std::endl;
-			}
-			else
-			{
-				app.StartRecording();
-				std::cout << "Recording started" << std::endl;
-			}
+			app.StopRecording();
+			app.StartRecording();
+			std::cout << "Recording started" << std::endl;
 			last_toggle = now;
 		}
 

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -104,7 +104,7 @@ static void event_loop(RPiCamEncoder &app)
 		//	output->Signal();
 		if (key == '\n')  // For example, if Enter key is pressed
 		{
-			if (app.isRecording())
+			if (app.IsRecording())
 				app.StopRecording();
 			else
 				app.StartRecording();  // No need to provide a filename

--- a/core/meson.build
+++ b/core/meson.build
@@ -26,6 +26,7 @@ core_headers = files([
     'stream_info.hpp',
     'version.hpp',
     'video_options.hpp',
+    'recording_manager.hpp',
 ])
 
 # Generate a version string.

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -289,7 +289,9 @@ Options::Options()
 		("flicker-period", value<std::string>(&flicker_period_)->default_value("0s"),
 			"Manual flicker correction period"
 			"\nSet to 10000us to cancel 50Hz flicker."
-			"\nSet to 8333us to cancel 60Hz flicker.\n")
+			"\nSet to 8333us to cancel 60Hz flicker.\n"),
+		("record-detection", value<unsigned int>(&record_detection)->default_value(0),
+			"Set the duration (in seconds) to continue recording after object detection")
 		;
 	// clang-format on
 

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -289,7 +289,7 @@ Options::Options()
 		("flicker-period", value<std::string>(&flicker_period_)->default_value("0s"),
 			"Manual flicker correction period"
 			"\nSet to 10000us to cancel 50Hz flicker."
-			"\nSet to 8333us to cancel 60Hz flicker.\n"),
+			"\nSet to 8333us to cancel 60Hz flicker.\n")
 		("record-detection", value<unsigned int>(&record_detection)->default_value(0),
 			"Set the duration (in seconds) to continue recording after object detection")
 		;

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -174,6 +174,7 @@ struct Options
 	std::string hdr;
 	TimeVal<std::chrono::microseconds> flicker_period;
 	bool no_raw;
+	unsigned int record_detection;
 
 	virtual bool Parse(int argc, char *argv[]);
 	virtual void Print() const;

--- a/core/recording_manager.hpp
+++ b/core/recording_manager.hpp
@@ -1,7 +1,11 @@
+// recording_manager.hpp
+
 #pragma once
 
 #include <mutex>
 #include <chrono>
+#include <optional>
+#include <iostream>
 
 class RecordingManager {
 public:
@@ -12,13 +16,17 @@ public:
 
 	void objectDetected() {
 		std::lock_guard<std::mutex> lock(mutex_);
+		std::cout << "Object detected" << std::endl;
 		last_detection_time_ = std::chrono::steady_clock::now();
 	}
 
 	bool shouldRecord() {
 		std::lock_guard<std::mutex> lock(mutex_);
+		if (!last_detection_time_) {
+			return false;  // No object has been detected yet
+		}
 		auto now = std::chrono::steady_clock::now();
-		auto time_since_last_detection = std::chrono::duration_cast<std::chrono::seconds>(now - last_detection_time_).count();
+		auto time_since_last_detection = std::chrono::duration_cast<std::chrono::seconds>(now - *last_detection_time_).count();
 		return time_since_last_detection <= post_detection_record_time_;
 	}
 
@@ -28,12 +36,12 @@ public:
 	}
 
 private:
-	RecordingManager() : last_detection_time_(std::chrono::steady_clock::now()), post_detection_record_time_(30) {}
+	RecordingManager() : post_detection_record_time_(30) {}
 
 	RecordingManager(const RecordingManager&) = delete;
 	RecordingManager& operator=(const RecordingManager&) = delete;
 
-	std::chrono::steady_clock::time_point last_detection_time_;
+	std::optional<std::chrono::steady_clock::time_point> last_detection_time_;
 	int post_detection_record_time_; // in seconds
 	std::mutex mutex_;
 };

--- a/core/recording_manager.hpp
+++ b/core/recording_manager.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <mutex>
+#include <chrono>
+
+class RecordingManager {
+public:
+	static RecordingManager& getInstance() {
+		static RecordingManager instance;
+		return instance;
+	}
+
+	void objectDetected() {
+		std::lock_guard<std::mutex> lock(mutex_);
+		last_detection_time_ = std::chrono::steady_clock::now();
+	}
+
+	bool shouldRecord() {
+		std::lock_guard<std::mutex> lock(mutex_);
+		auto now = std::chrono::steady_clock::now();
+		auto time_since_last_detection = std::chrono::duration_cast<std::chrono::seconds>(now - last_detection_time_).count();
+		return time_since_last_detection <= post_detection_record_time_;
+	}
+
+	void setPostDetectionRecordTime(int seconds) {
+		std::lock_guard<std::mutex> lock(mutex_);
+		post_detection_record_time_ = seconds;
+	}
+
+private:
+	RecordingManager() : last_detection_time_(std::chrono::steady_clock::now()), post_detection_record_time_(30) {}
+
+	RecordingManager(const RecordingManager&) = delete;
+	RecordingManager& operator=(const RecordingManager&) = delete;
+
+	std::chrono::steady_clock::time_point last_detection_time_;
+	int post_detection_record_time_; // in seconds
+	std::mutex mutex_;
+};

--- a/core/recording_manager.hpp
+++ b/core/recording_manager.hpp
@@ -24,6 +24,9 @@ public:
 
 	bool shouldRecord() {
 		std::lock_guard<std::mutex> lock(mutex_);
+		if (!post_detection_record_time_) {
+			return false;
+		}
 		std::ifstream file(state_file_);
 		if (!file) {
 			return false;  // No object has been detected yet

--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <fcntl.h>
 #include <stdlib.h>
+#include <filesystem>
 
 #include <sys/ioctl.h>
 #include <sys/stat.h>
@@ -1206,18 +1207,18 @@ void RPiCamApp::StartRecording()
 	{
 		is_recording_ = true;
 
-		// Generate filename based on current timestamp
 		auto now = std::chrono::system_clock::now();
 		auto in_time_t = std::chrono::system_clock::to_time_t(now);
 
 		std::stringstream ss;
 		ss << std::put_time(std::localtime(&in_time_t), "%Y%m%d_%H%M%S");
 
-		std::filesystem::path output_dir = "recordings";  // You can change this to your desired directory
-		std::filesystem::create_directories(output_dir);  // Ensure the directory exists
+		std::filesystem::path output_dir = "recordings";
+		std::filesystem::create_directories(output_dir);
 
 		recording_file_ = (output_dir / (ss.str() + ".mp4")).string();
 
+		// Assuming encoder_ is a member variable of type std::unique_ptr<Encoder>
 		encoder_->SetOutputFile(recording_file_);
 
 		LOG(2, "Started recording to file: " << recording_file_);

--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -1200,37 +1200,3 @@ void RPiCamApp::configureDenoise(const std::string &denoise_mode)
 
 	controls_.set(NoiseReductionMode, denoise);
 }
-
-void RPiCamApp::StartRecording()
-{
-	if (!is_recording_)
-	{
-		is_recording_ = true;
-
-		auto now = std::chrono::system_clock::now();
-		auto in_time_t = std::chrono::system_clock::to_time_t(now);
-
-		std::stringstream ss;
-		ss << std::put_time(std::localtime(&in_time_t), "%Y%m%d_%H%M%S");
-
-		std::filesystem::path output_dir = "recordings";
-		std::filesystem::create_directories(output_dir);
-
-		recording_file_ = (output_dir / (ss.str() + ".mp4")).string();
-
-		// Assuming encoder_ is a member variable of type std::unique_ptr<Encoder>
-		encoder_->SetOutputFile(recording_file_);
-
-		LOG(2, "Started recording to file: " << recording_file_);
-	}
-}
-
-void RPiCamApp::StopRecording()
-{
-	if (is_recording_)
-	{
-		is_recording_ = false;
-		encoder_->ClearOutputFile();
-		LOG(2, "Stopped recording");
-	}
-}

--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -14,10 +14,6 @@
 #include <cmath>
 #include <fcntl.h>
 #include <stdlib.h>
-#include <chrono>
-#include <iomanip>
-#include <sstream>
-#include <filesystem>
 
 #include <sys/ioctl.h>
 #include <sys/stat.h>
@@ -1222,7 +1218,7 @@ void RPiCamApp::StartRecording()
 
 		recording_file_ = (output_dir / (ss.str() + ".mp4")).string();
 
-		static_cast<LibAvEncoder*>(encoder_.get())->SetOutputFile(recording_file_);
+		encoder_->SetOutputFile(recording_file_);
 
 		LOG(2, "Started recording to file: " << recording_file_);
 	}
@@ -1233,6 +1229,7 @@ void RPiCamApp::StopRecording()
 	if (is_recording_)
 	{
 		is_recording_ = false;
-		static_cast<LibAvEncoder*>(encoder_.get())->StopRecording();
+		encoder_->ClearOutputFile();
+		LOG(2, "Stopped recording");
 	}
 }

--- a/core/rpicam_app.hpp
+++ b/core/rpicam_app.hpp
@@ -143,9 +143,6 @@ public:
 	void StartCamera();
 	void StopCamera();
 
-	void StartRecording();
-	void StopRecording();
-
 	Msg Wait();
 	void PostMessage(MsgType &t, MsgPayload &p);
 
@@ -284,5 +281,4 @@ private:
 	uint64_t last_timestamp_;
 	uint64_t sequence_ = 0;
 	PostProcessor post_processor_;
-	bool is_recording_ = false;
 };

--- a/core/rpicam_app.hpp
+++ b/core/rpicam_app.hpp
@@ -284,4 +284,6 @@ private:
 	uint64_t last_timestamp_;
 	uint64_t sequence_ = 0;
 	PostProcessor post_processor_;
+	bool is_recording_ = false;
+	std::string recording_file_;
 };

--- a/core/rpicam_app.hpp
+++ b/core/rpicam_app.hpp
@@ -143,6 +143,9 @@ public:
 	void StartCamera();
 	void StopCamera();
 
+	void StartRecording();
+	void StopRecording();
+
 	Msg Wait();
 	void PostMessage(MsgType &t, MsgPayload &p);
 
@@ -281,4 +284,5 @@ private:
 	uint64_t last_timestamp_;
 	uint64_t sequence_ = 0;
 	PostProcessor post_processor_;
+	bool is_recording_ = false;
 };

--- a/core/rpicam_app.hpp
+++ b/core/rpicam_app.hpp
@@ -143,8 +143,8 @@ public:
 	void StartCamera();
 	void StopCamera();
 
-	void StartRecording();
-	void StopRecording();
+	virtual void StartRecording() = 0;
+	virtual void StopRecording() = 0;
 
 	Msg Wait();
 	void PostMessage(MsgType &t, MsgPayload &p);
@@ -286,4 +286,5 @@ private:
 	PostProcessor post_processor_;
 	bool is_recording_ = false;
 	std::string recording_file_;
+
 };

--- a/core/rpicam_app.hpp
+++ b/core/rpicam_app.hpp
@@ -143,6 +143,9 @@ public:
 	void StartCamera();
 	void StopCamera();
 
+	void StartRecording();
+	void StopRecording();
+
 	Msg Wait();
 	void PostMessage(MsgType &t, MsgPayload &p);
 

--- a/core/rpicam_app.hpp
+++ b/core/rpicam_app.hpp
@@ -143,8 +143,8 @@ public:
 	void StartCamera();
 	void StopCamera();
 
-	virtual void StartRecording() = 0;
-	virtual void StopRecording() = 0;
+	virtual void StartRecording() {};
+	virtual void StopRecording() {};
 
 	Msg Wait();
 	void PostMessage(MsgType &t, MsgPayload &p);

--- a/core/rpicam_app.hpp
+++ b/core/rpicam_app.hpp
@@ -145,6 +145,7 @@ public:
 
 	virtual void StartRecording() {};
 	virtual void StopRecording() {};
+	bool IsRecording() const { return is_recording_; }
 
 	Msg Wait();
 	void PostMessage(MsgType &t, MsgPayload &p);

--- a/core/rpicam_encoder.hpp
+++ b/core/rpicam_encoder.hpp
@@ -98,6 +98,7 @@ public:
 			{
 				// Flush the encoder
 				encoder_->EncodeBuffer(-1, 0, nullptr, StreamInfo(), 0);
+				encoder_->Flush();
 				// Clear the output file after flushing
 				encoder_->ClearOutputFile();
 			}

--- a/core/rpicam_encoder.hpp
+++ b/core/rpicam_encoder.hpp
@@ -102,6 +102,8 @@ public:
 		}
 	}
 
+	bool IsRecording() const { return is_recording_; }
+
 
 protected:
 	virtual void createEncoder()

--- a/core/rpicam_encoder.hpp
+++ b/core/rpicam_encoder.hpp
@@ -97,8 +97,8 @@ public:
 			if (encoder_)
 			{
 				// Flush the encoder
-				encoder_->EncodeBuffer(-1, 0, nullptr, StreamInfo(), 0);
-				encoder_->Flush();
+				// encoder_->EncodeBuffer(-1, 0, nullptr, StreamInfo(), 0);
+				// encoder_->Flush();
 				// Clear the output file after flushing
 				encoder_->ClearOutputFile();
 			}

--- a/core/rpicam_encoder.hpp
+++ b/core/rpicam_encoder.hpp
@@ -96,6 +96,9 @@ public:
 
 			if (encoder_)
 			{
+				// Flush the encoder
+				encoder_->EncodeBuffer(-1, 0, nullptr, StreamInfo(), 0);
+				// Clear the output file after flushing
 				encoder_->ClearOutputFile();
 			}
 		}

--- a/core/rpicam_encoder.hpp
+++ b/core/rpicam_encoder.hpp
@@ -91,14 +91,13 @@ public:
 	{
 		if (is_recording_)
 		{
+			std::cout << "Recording stopped" << std::endl;
 			is_recording_ = false;
 
 			if (encoder_)
 			{
 				encoder_->ClearOutputFile();
 			}
-
-			LOG(2, "Stopped recording");
 		}
 	}
 

--- a/core/rpicam_encoder.hpp
+++ b/core/rpicam_encoder.hpp
@@ -82,6 +82,7 @@ public:
 				encoder_->SetOutputFile(recording_file_);
 			}
 
+			std::cout << "Started recording to file: " << recording_file_ << std::endl;
 			LOG(2, "Started recording to file: " << recording_file_);
 		}
 	}

--- a/encoder/encoder.hpp
+++ b/encoder/encoder.hpp
@@ -33,6 +33,9 @@ public:
 	// describing a DMABUF, and by a mmapped userland pointer.
 	virtual void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) = 0;
 
+	virtual void SetOutputFile(const std::string &output_file) = 0;
+	virtual void ClearOutputFile() = 0;
+
 protected:
 	InputDoneCallback input_done_callback_;
 	OutputReadyCallback output_ready_callback_;

--- a/encoder/encoder.hpp
+++ b/encoder/encoder.hpp
@@ -35,6 +35,7 @@ public:
 
 	virtual void SetOutputFile(const std::string &output_file) = 0;
 	virtual void ClearOutputFile() = 0;
+	virtual void Flush() = 0;
 
 protected:
 	InputDoneCallback input_done_callback_;

--- a/encoder/h264_encoder.hpp
+++ b/encoder/h264_encoder.hpp
@@ -23,6 +23,7 @@ public:
 	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) override;
 	void SetOutputFile(const std::string &output_file) override {};
 	void ClearOutputFile() override {};
+	void Flush() override {};
 
 private:
 	// We want at least as many output buffers as there are in the camera queue

--- a/encoder/h264_encoder.hpp
+++ b/encoder/h264_encoder.hpp
@@ -21,6 +21,8 @@ public:
 	~H264Encoder();
 	// Encode the given DMABUF.
 	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) override;
+	void SetOutputFile(const std::string &output_file) override {};
+	void ClearOutputFile() override {};
 
 private:
 	// We want at least as many output buffers as there are in the camera queue

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -242,12 +242,13 @@ void LibAvEncoder::initVideoCodec(VideoOptions const *options, StreamInfo const 
 	//
 	// This seems to be a limitation/bug in ffmpeg:
 	// https://github.com/FFmpeg/FFmpeg/blob/3141dbb7adf1e2bd5b9ff700312d7732c958b8df/libavformat/avienc.c#L527
-	if (!strncmp(out_fmt_ctx_->oformat->name, "avi", 3))
+	if (!strncmp(out_fmt_ctx_->oformat->name, "avi", 3)) {
 		stream_[Video]->time_base = { 1000, (int)(options->framerate.value_or(DEFAULT_FRAMERATE) * 1000) };
-	else
+	} else {
 		stream_[Video]->time_base = codec_ctx_[Video]->time_base;
 		int framerate = static_cast<int>(std::round(options->framerate.value_or(DEFAULT_FRAMERATE) * 1000));
 		codec_ctx_[Video]->time_base = AVRational{1, framerate};
+	}
 
 	stream_[Video]->avg_frame_rate = stream_[Video]->r_frame_rate = codec_ctx_[Video]->framerate;
 	avcodec_parameters_from_context(stream_[Video]->codecpar, codec_ctx_[Video]);

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -195,6 +195,8 @@ void LibAvEncoder::initVideoCodec(VideoOptions const *options, StreamInfo const 
 	else
 		format = options->libav_format.c_str();
 
+	std::cout << format << "\n";
+
 	// Legacy handling of the --listen parameter.  If missing from the url string, add "?listen=1" to the end.
 	if (options->listen && output_file_.find(tcp.c_str(), 0, tcp.length()) != std::string::npos)
 	{
@@ -405,8 +407,8 @@ void LibAvEncoder::EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const
 	frame->linesize[1] = frame->linesize[2] = info.stride >> 1;
 
 	// Calculate PTS in codec's timebase
-	int64_t pts_us = timestamp_us - video_start_ts_ +
-					 (options_->av_sync.value < 0us ? -options_->av_sync.get<std::chrono::microseconds>() : 0);
+	//int64_t pts_us = timestamp_us - video_start_ts_ +
+	//				 (options_->av_sync.value < 0us ? -options_->av_sync.get<std::chrono::microseconds>() : 0);
 	frame->pts = av_rescale_q(timestamp_us - video_start_ts_, AV_TIME_BASE_Q, codec_ctx_[Video]->time_base);
 
 	if (codec_ctx_[Video]->pix_fmt == AV_PIX_FMT_DRM_PRIME)

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -495,7 +495,7 @@ void LibAvEncoder::deinitOutput()
 	}
 
 	// Reset the context, but don't free it as it might be reused
-	avformat_flush(out_fmt_ctx_);
+	// avformat_flush(out_fmt_ctx_);
 }
 
 void LibAvEncoder::encode(AVPacket *pkt, unsigned int stream_id)

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -748,3 +748,23 @@ void LibAvEncoder::audioThread()
 	av_packet_free(&out_pkt);
 	av_frame_free(&in_frame);
 }
+
+void LibAvEncoder::SetOutputFile(const std::string &output_file)
+{
+	if (output_file_ != output_file)
+	{
+		deinitOutput();
+		output_file_ = output_file;
+		initOutput();
+	}
+}
+
+void LibAvEncoder::ClearOutputFile()
+{
+	if (!output_file_.empty())
+	{
+		deinitOutput();
+		output_file_ = "/dev/null";
+		initOutput();
+	}
+}

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -770,7 +770,7 @@ void LibAvEncoder::SetOutputFile(const std::string &output_file)
 	{
 		deinitOutput();
 		output_file_ = output_file;
-		resetTimestamp();
+		// resetTimestamp();
 		initOutput();
 	}
 }

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -770,6 +770,7 @@ void LibAvEncoder::SetOutputFile(const std::string &output_file)
 	{
 		deinitOutput();
 		output_file_ = output_file;
+		resetTimestamp();
 		initOutput();
 	}
 }

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -617,8 +617,6 @@ void LibAvEncoder::videoThread()
 	}
 
 	done:
-		// Flush the encoder
-		avcodec_send_frame(codec_ctx_[Video], nullptr);
 	encode(pkt, Video);
 
 	av_packet_free(&pkt);
@@ -814,14 +812,6 @@ void LibAvEncoder::Flush()
 {
 	AVPacket *pkt = av_packet_alloc();
 	int ret;
-
-	// Send NULL to signal end of stream
-	ret = avcodec_send_frame(codec_ctx_[Video], NULL);
-	if (ret < 0) {
-		LOG_ERROR("Error sending EOF frame");
-		av_packet_free(&pkt);
-		return;
-	}
 
 	while (ret >= 0) {
 		ret = avcodec_receive_packet(codec_ctx_[Video], pkt);

--- a/encoder/libav_encoder.hpp
+++ b/encoder/libav_encoder.hpp
@@ -55,6 +55,7 @@ private:
 	void audioThread();
 
 	static void releaseBuffer(void *opaque, uint8_t *data);
+	void resetTimestamp();
 
 	std::atomic<bool> output_ready_;
 	bool abort_video_;

--- a/encoder/libav_encoder.hpp
+++ b/encoder/libav_encoder.hpp
@@ -41,6 +41,7 @@ public:
 
 	void SetOutputFile(const std::string &output_file);
 	void ClearOutputFile();
+	void Flush();
 
 private:
 	void initVideoCodec(VideoOptions const *options, StreamInfo const &info);

--- a/encoder/libav_encoder.hpp
+++ b/encoder/libav_encoder.hpp
@@ -55,7 +55,7 @@ private:
 	void audioThread();
 
 	static void releaseBuffer(void *opaque, uint8_t *data);
-	void resetTimestamp();
+	void resetTimestamp() { video_start_ts_ = 0; }
 
 	std::atomic<bool> output_ready_;
 	bool abort_video_;

--- a/encoder/libav_encoder.hpp
+++ b/encoder/libav_encoder.hpp
@@ -55,7 +55,7 @@ private:
 	void audioThread();
 
 	static void releaseBuffer(void *opaque, uint8_t *data);
-	void resetTimestamp() { video_start_ts_ = 0; }
+	// void resetTimestamp() { video_start_ts_ = 0; }
 
 	std::atomic<bool> output_ready_;
 	bool abort_video_;

--- a/encoder/libav_encoder.hpp
+++ b/encoder/libav_encoder.hpp
@@ -39,6 +39,9 @@ public:
 	// Encode the given DMABUF.
 	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) override;
 
+	void SetOutputFile(const std::string &output_file);
+	void ClearOutputFile();
+
 private:
 	void initVideoCodec(VideoOptions const *options, StreamInfo const &info);
 	void initAudioInCodec(VideoOptions const *options, StreamInfo const &info);

--- a/encoder/libav_encoder.hpp
+++ b/encoder/libav_encoder.hpp
@@ -56,7 +56,6 @@ private:
 	void audioThread();
 
 	static void releaseBuffer(void *opaque, uint8_t *data);
-	// void resetTimestamp() { video_start_ts_ = 0; }
 
 	std::atomic<bool> output_ready_;
 	bool abort_video_;

--- a/encoder/mjpeg_encoder.hpp
+++ b/encoder/mjpeg_encoder.hpp
@@ -25,6 +25,7 @@ public:
 	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) override;
 	void SetOutputFile(const std::string &output_file) override {};
 	void ClearOutputFile() override {};
+	void Flush() override {};
 
 private:
 	// How many threads to use. Whichever thread is idle will pick up the next frame.

--- a/encoder/mjpeg_encoder.hpp
+++ b/encoder/mjpeg_encoder.hpp
@@ -23,6 +23,8 @@ public:
 	~MjpegEncoder();
 	// Encode the given buffer.
 	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) override;
+	void SetOutputFile(const std::string &output_file) override {};
+	void ClearOutputFile() override {};
 
 private:
 	// How many threads to use. Whichever thread is idle will pick up the next frame.

--- a/encoder/null_encoder.hpp
+++ b/encoder/null_encoder.hpp
@@ -23,6 +23,7 @@ public:
 	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) override;
 	void SetOutputFile(const std::string &output_file) override {};
 	void ClearOutputFile() override {};
+	void Flush() override {};
 
 private:
 	void outputThread();

--- a/encoder/null_encoder.hpp
+++ b/encoder/null_encoder.hpp
@@ -21,6 +21,8 @@ public:
 	NullEncoder(VideoOptions const *options);
 	~NullEncoder();
 	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) override;
+	void SetOutputFile(const std::string &output_file) override {};
+	void ClearOutputFile() override {};
 
 private:
 	void outputThread();

--- a/post_processing_stages/hailo/hailo_yolo_inference.cpp
+++ b/post_processing_stages/hailo/hailo_yolo_inference.cpp
@@ -171,7 +171,7 @@ bool YoloInference::Process(CompletedRequestPtr &completed_request)
 	std::vector<Detection> objects = runInference(input.get());
 	if (objects.size())
 	{
-		RecordingManager::getInstance().objectDetected();
+		RecordingManager::getInstance().objectDetected(objects);
 		if (temporal_filtering_)
 		{
 			// Process() can be concurrently called through different threads for consecutive CompletedRequests if

--- a/post_processing_stages/hailo/hailo_yolo_inference.cpp
+++ b/post_processing_stages/hailo/hailo_yolo_inference.cpp
@@ -16,6 +16,7 @@
 #include <libcamera/geometry.h>
 
 #include "core/rpicam_app.hpp"
+#include "core/recording_manager.hpp"
 #include "post_processing_stages/object_detect.hpp"
 
 #include "detection/yolo_postprocess.hpp"
@@ -170,6 +171,7 @@ bool YoloInference::Process(CompletedRequestPtr &completed_request)
 	std::vector<Detection> objects = runInference(input.get());
 	if (objects.size())
 	{
+		RecordingManager::getInstance().objectDetected();
 		if (temporal_filtering_)
 		{
 			// Process() can be concurrently called through different threads for consecutive CompletedRequests if

--- a/post_processing_stages/hailo/meson.build
+++ b/post_processing_stages/hailo/meson.build
@@ -1,5 +1,6 @@
 hailo_tappas_lib_dir = hailo_tappas_dep.get_variable('tappas_libdir')
 hailo_tappas_posproc_libdir = hailo_tappas_lib_dir / 'post-process'
+assets_dir = '/home/matteius/Projects/rpicam-apps-opensensor/assets' 
 
 hailo_conf_data = configuration_data()
 hailo_conf_data.set('HAILO_POSTPROC_LIB_DIR', '"' + hailo_tappas_posproc_libdir + '"')
@@ -21,7 +22,7 @@ hailo_postprocessing_src = files([
     'hailo_classifier.cpp',
 ])
 
-postproc_assets += files([
+postproc_assets = files([
     assets_dir / 'hailo_classifier.json',
     assets_dir / 'hailo_yolov5_personface.json',
     assets_dir / 'hailo_yolov6_inference.json',

--- a/post_processing_stages/meson.build
+++ b/post_processing_stages/meson.build
@@ -4,10 +4,6 @@ conf_data = configuration_data()
 conf_data.set('POSTPROC_LIB_DIR', '"' + posproc_libdir + '"')
 configure_file(output : 'postproc_lib.h', configuration : conf_data)
 
-# JSON (and other assets)
-assets_dir = meson.project_source_root() / 'assets'
-postproc_assets = []
-
 # Core postprocessing framework files.
 rpicam_app_src += files([
     'histogram.cpp',
@@ -20,13 +16,6 @@ core_postproc_src = files([
     'hdr_stage.cpp',
     'motion_detect_stage.cpp',
     'negate_stage.cpp',
-])
-
-# Core assets
-postproc_assets += files([
-    assets_dir / 'hdr.json',
-    assets_dir / 'motion_detect.json',
-    assets_dir / 'negate.json',
 ])
 
 core_postproc_lib = shared_module('core-postproc', core_postproc_src,
@@ -50,13 +39,6 @@ if opencv_dep.found()
         'object_detect_draw_cv_stage.cpp',
     ])
 
-    # OpenCV assets
-    postproc_assets += files([
-        assets_dir / 'sobel_cv.json',
-        assets_dir / 'face_detect_cv.json',
-        assets_dir / 'annotate_cv.json',
-    ])
-
     opencv_postproc_lib = shared_module('opencv-postproc', opencv_postproc_src,
                                         include_directories : '../..',
                                         dependencies : [libcamera_dep, opencv_dep],
@@ -75,17 +57,9 @@ if tflite_dep.found()
     tflite_postproc_src = files([
         'tf_stage.cpp',
         'object_classify_tf_stage.cpp',
-        'object_detect_tf_stage.cpp',
         'pose_estimation_tf_stage.cpp',
+        'object_detect_tf_stage.cpp',
         'segmentation_tf_stage.cpp',
-    ])
-
-    # TFlite assets
-    postproc_assets += files([
-        assets_dir / 'object_classify_tf.json',
-        assets_dir / 'object_detect_tf.json',
-        assets_dir / 'pose_estimation_tf.json',
-        assets_dir / 'segmentation_tf.json',
     ])
 
     tflite_postproc_lib = shared_module('tflite-postproc', tflite_postproc_src,
@@ -103,7 +77,7 @@ endif
 enable_hailo = false
 hailort_dep = dependency('HailoRT', modules : ['HailoRT::libhailort'], version: '>=4.17.0',
                          required : get_option('enable_hailo'))
-hailo_tappas_dep = dependency('hailo-tappas-core', required : get_option('enable_hailo'))
+hailo_tappas_dep = dependency('hailo_tappas', required : get_option('enable_hailo'))
 if hailort_dep.found() and hailo_tappas_dep.found()
     subdir('hailo')
     enable_hailo = true
@@ -119,4 +93,3 @@ post_processing_headers = files([
 ])
 
 install_headers(post_processing_headers, subdir: meson.project_name() / 'post_processing_stages')
-install_data(postproc_assets, install_dir : get_option('datadir') / 'rpi-camera-assets')


### PR DESCRIPTION
I want to take a pulse on accepting new features back to the mainline repository.
In my initial exploration of the Hailo AI module, I discovered its possible to record continuously to a file or not at all, however I had a strong desire to trigger recordings based on object detections.

I have a surprising amount of time into these code changes already as I had tried a few approaches that flopped prior.

Current features I've added:
* Added a new RecordingManager class to manage the recording state and trigger recordings based on object detections which is behind an options flag --record-detection <seconds>.  The default is 0 meaning it does not invoke this feature.
* I also generate a detections log file that records the detection and the time they were detected.  This is useful for debugging and understanding the behavior of the object detection.  I should hide this behind an options flag as well.
* Seems that the post-processing run in a separate process and so I use a shared tmp file to communicate recording state between detection process and the actual app.

Current limitations:
* The mp4 containers I generate are not perfect because I start writing to the container as soon as object is detected which is likely before the next key frame.   These play fine in ffplay and vlc, but generally I have been running something like `ffmpeg -i 20240706_074707.mp4 -c copy -map 0 20240706_074707_remuxed.mp4` to clean up the recording files.
* my home directory is hardcoded in at least one spot.
* Only implemented in the rpicam-vid application and the hailo_yolo_inference post processor.

Future work:
* I will likely be doing more in this space, I plant to update the app to have an option of whether to draw the post-processing in the video feed or hide it, as well as put my detection log behind an options flag.
* Would love to generate a more perfect mp4 container with initial key frame+metadata, but I'm not sure how to do that yet.

