### PR TITLE
Update tf_stage.cpp - corrected Inference time display unit

### DIFF
--- a/post_processing_stages/tf_stage.cpp
+++ b/post_processing_stages/tf_stage.cpp
@@ -113,7 +113,7 @@ bool TfStage::Process(CompletedRequestPtr &completed_request)
 				auto time_taken = ExecutionTime<std::micro>(&TfStage::runInference, this).count();
 
 				if (config_->verbose)
-					LOG(1, "TfStage: Inference time: " << time_taken << " ms");
+					LOG(1, "TfStage: Inference time: " << time_taken << " us");
 			});
 		}
 	}


### PR DESCRIPTION
The inference time (time_taken) is displayed as "ms" which is the standard abbreviation for millisecond, however the variable time_taken is declared in microseconds. The abbreviate for that is "us" if displayed with a standard character set.

auto time_taken = ExecutionTime<std::micro>(&TfStage::runInference, this).count();