### PR TITLE
core: Better handling of IMX708 sensor HDR

### DIFF
--- a/core/options.cpp
+++ b/core/options.cpp
@@ -6,6 +6,7 @@
  */
 #include <algorithm>
 #include <fcntl.h>
+#include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <linux/v4l2-controls.h>
@@ -19,6 +20,8 @@
 #include <libcamera/property_ids.h>
 
 #include "core/options.hpp"
+
+namespace fs = std::filesystem;
 
 static const std::map<int, std::string> cfa_map =
 {
@@ -104,31 +107,41 @@ static int xioctl(int fd, unsigned long ctl, void *arg)
 	return ret;
 }
 
-static bool set_subdev_hdr_ctrl(int en)
+static bool set_imx708_subdev_hdr_ctrl(int en, const std::string &cam_id)
 {
-	bool changed = false;
-	// Currently this does not exist in libcamera, so go directly to V4L2
-	// XXX it's not obvious which v4l2-subdev to use for which camera!
-	for (int i = 0; i < 8; i++)
+	for (unsigned int i = 0; i < 16; i++)
 	{
-		std::string dev("/dev/v4l-subdev");
-		dev += (char)('0' + i);
-		int fd = open(dev.c_str(), O_RDWR, 0);
-		if (fd < 0)
-			continue;
+		const fs::path test_dir { "/sys/class/video4linux/v4l-subdev" + std::to_string(i) + "/device" };
+		const fs::path module_dir { test_dir.string() + "/driver/module" };
+		const fs::path id_dir { test_dir.string() + "/of_node" };
 
-		v4l2_control ctrl { V4L2_CID_WIDE_DYNAMIC_RANGE, en };
-		if (!xioctl(fd, VIDIOC_G_CTRL, &ctrl) && ctrl.value != en)
+		if (fs::exists(module_dir) && fs::is_symlink(module_dir))
 		{
-			ctrl.value = en;
-			if (!xioctl(fd, VIDIOC_S_CTRL, &ctrl))
-				changed = true;
-		}
-		close(fd);
-	}
-	return changed;
-}
+			fs::path ln = fs::read_symlink(module_dir);
+			if (ln.string().find("imx708") != std::string::npos &&
+				fs::is_symlink(id_dir) && fs::read_symlink(id_dir).string().find(cam_id) != std::string::npos)
+			{
+				const std::string dev_node { "/dev/v4l-subdev" + std::to_string(i) };
+				int fd = open(dev_node.c_str(), O_RDONLY, 0);
+				if (fd < 0)
+					continue;
 
+				v4l2_control ctrl { V4L2_CID_WIDE_DYNAMIC_RANGE, en };
+				if (!xioctl(fd, VIDIOC_G_CTRL, &ctrl) && ctrl.value != en)
+				{
+					ctrl.value = en;
+					if (!xioctl(fd, VIDIOC_S_CTRL, &ctrl))
+					{
+						close(fd);
+						return true;
+					}
+				}
+				close(fd);
+			}
+		}
+	}
+	return false;
+}
 
 Platform get_platform()
 {
@@ -364,10 +377,6 @@ bool Options::Parse(int argc, char *argv[])
 	if (!verbose || list_cameras)
 		libcamera::logSetTarget(libcamera::LoggingTargetNone);
 
-	// HDR control. Set the sensor control before opening or listing any cameras.
-	// Start by disabling HDR unconditionally. Reset the camera manager if we have
-	// actually switched the value of the control.
-	set_subdev_hdr_ctrl(0);
 	app_->initCameraManager();
 
 	bool log_env_set = getenv("LIBCAMERA_LOG_LEVELS");
@@ -379,16 +388,27 @@ bool Options::Parse(int argc, char *argv[])
 	if (camera < cameras.size())
 	{
 		const std::string cam_id = *cameras[camera]->properties().get(libcamera::properties::Model);
-		if ((hdr == "sensor" || hdr == "auto") && cam_id.find("imx708") != std::string::npos)
+
+		if (cam_id.find("imx708") != std::string::npos)
 		{
-			// Turn on sensor HDR.  Reset the camera manager if we have switched the value of the control.
-			if (set_subdev_hdr_ctrl(1))
+			// HDR control. Set the sensor control before opening or listing any cameras.
+			// Start by disabling HDR unconditionally. Reset the camera manager if we have
+			// actually switched the value of the control
+			bool changed = set_imx708_subdev_hdr_ctrl(0, cameras[camera]->id());
+
+			if (hdr == "sensor" || hdr == "auto")
+			{
+				// Turn on sensor HDR.  Reset the camera manager if we have switched the value of the control.
+				changed |= set_imx708_subdev_hdr_ctrl(1, cameras[camera]->id());
+				hdr = "sensor";
+			}
+
+			if (changed)
 			{
 				cameras.clear();
 				app_->initCameraManager();
 				cameras = app_->GetCameras();
 			}
-			hdr = "sensor";
 		}
 	}
 


### PR DESCRIPTION
Do not set HDR control switch on all IMX708 subdev nodes available. Rather, traverse through sysfs and find the correct subdev node to toggle the HDR control on and off. We aim to match the selected camera device id when deciding which subdev node to use.