### PR TITLE
gen_orig.yml: fix workflow

### DIFF
--- a/.github/workflows/gen_orig.yml
+++ b/.github/workflows/gen_orig.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Release tarball
         uses: softprops/action-gh-release@v1
         with:
-          files: build/meson-dist/*.tar.xz hailo-models-*.tar.xz
+          files: |
+            build/meson-dist/*.tar.xz
+            hailo-models-*.tar.xz
       - if: failure()
         run: cat build/meson-logs/meson-log.txt


### PR DESCRIPTION
The previous version treats `build/meson-dist/*.tar.xz hailo-models-*.tar.xz` as a single file, which it fails to find.