### PR TITLE
rpicam-vid: Update for camera sync algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 *~
+.vscode/

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -117,7 +117,6 @@ static void event_loop(RPiCamEncoder &app)
 			app.StopEncoder();
 			return;
 		}
-
 		CompletedRequestPtr &completed_request = std::get<CompletedRequestPtr>(msg.payload);
 		app.EncodeBuffer(completed_request, app.VideoStream());
 		app.ShowPreview(completed_request, app.VideoStream());

--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -161,6 +161,8 @@ struct VideoOptions : public Options
 			("low-latency", value<bool>(&low_latency)->default_value(false)->implicit_value(true),
 			 "Enables the libav/libx264 low latncy presets for video encoding.")
 #endif
+			 ("sync", value<std::string>(&sync_)->default_value("off"),
+			  "Whether to synchronise with another camera. Use \"off\", \"server\" or \"client\".")
 			;
 		// clang-format on
 	}
@@ -194,6 +196,7 @@ struct VideoOptions : public Options
 	size_t circular;
 	uint32_t frames;
 	bool low_latency;
+	uint32_t sync;
 
 	virtual bool Parse(int argc, char *argv[]) override
 	{
@@ -238,6 +241,15 @@ struct VideoOptions : public Options
 			level = "4.2";
 		}
 
+		if (strcasecmp(sync_.c_str(), "off") == 0)
+			sync = 0;
+		else if (strcasecmp(sync_.c_str(), "server") == 0)
+			sync = 1;
+		else if (strcasecmp(sync_.c_str(), "client") == 0)
+			sync = 2;
+		else
+			throw std::runtime_error("incorrect sync value " + sync_);
+
 		return true;
 	}
 	virtual void Print() const override
@@ -257,6 +269,7 @@ struct VideoOptions : public Options
 		std::cerr << "    split: " << split << std::endl;
 		std::cerr << "    segment: " << segment << std::endl;
 		std::cerr << "    circular: " << circular << std::endl;
+		std::cerr << "    sync: " << sync << std::endl;
 	}
 
 private:
@@ -265,4 +278,5 @@ private:
 	std::string av_sync_;
 	std::string audio_bitrate_;
 #endif /* LIBAV_PRESENT */
+	std::string sync_;
 };


### PR DESCRIPTION
A "sync" option has been added, which may take the values "server" or "client", turning the camera into either the server of client of a synchronised recording.

Recording only starts once the sync algorithm flag that the cameras are "ready to go".