### PR TITLE
postprocessing: hailo: Add singeton for vdevice

### DIFF
--- a/post_processing_stages/hailo/hailo_postprocessing_stage.hpp
+++ b/post_processing_stages/hailo/hailo_postprocessing_stage.hpp
@@ -123,7 +123,7 @@ protected:
 
 	Allocator allocator_;
 
-	std::unique_ptr<hailort::VDevice> vdevice_;
+	hailort::VDevice *vdevice_;
 	std::shared_ptr<hailort::InferModel> infer_model_;
 	std::shared_ptr<hailort::ConfiguredInferModel> configured_infer_model_;
 


### PR DESCRIPTION
The vdevice is a singelton and multiple Hailo postprocessing stages must use the same vdevice instance in order to acquire the hardware.