### PR TITLE
core: Use controls::ScalerCrop on VC4 platforms

### DIFF
--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -665,7 +665,10 @@ void RPiCamApp::StartCamera()
 			LOG(2, "Using crop (lores) " << crops.back().toString());
 		}
 
-		controls_.set(controls::rpi::ScalerCrops, libcamera::Span<const Rectangle>(crops.data(), crops.size()));
+		if (options_->GetPlatform() == Platform::VC4)
+			controls_.set(controls::ScalerCrop, crops[0]);
+		else
+			controls_.set(controls::rpi::ScalerCrops, libcamera::Span<const Rectangle>(crops.data(), crops.size()));
 	}
 
 	if (!controls_.get(controls::AfWindows) && !controls_.get(controls::AfMetering) && options_->afWindow_width != 0 &&

--- a/utils/test.py
+++ b/utils/test.py
@@ -117,6 +117,14 @@ def test_hello(exe_dir, output_dir):
     check_retcode(retcode, "test_hello: roi test")
     check_time(time_taken, 1, 6, "test_hello: roi test")
 
+    # "crops test". Specify an image crop with lores output and see if it blows up.
+    print("    crop test")
+    retcode, time_taken = run_executable(
+        [executable, '-t', '2000', '--roi', '0.25,0.25,0.5,0.5',
+         '--lores-width', '640', '--lores-height', '640'], logfile)
+    check_retcode(retcode, "test_hello: crop test")
+    check_time(time_taken, 1, 6, "test_hello: crop test")
+
     # "controls test". Specify some image controls and see if it blows up.
     print("    controls test")
     retcode, time_taken = run_executable(


### PR DESCRIPTION
The controls::rpi::ScalerCrops is only relevant to PiSP platforms in the upstream libcamera code.

Also while at it, add a test for crops.