### PR TITLE
libav: Add a low latency encode option

### DIFF
--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -158,6 +158,8 @@ struct VideoOptions : public Options
 			("av-sync", value<std::string>(&av_sync_)->default_value("0us"),
 			 "Add a time offset (in microseconds if no units provided) to the audio stream, relative to the video stream. "
 			 "The offset value can be either positive or negative.")
+			("low-latency", value<bool>(&low_latency)->default_value(false)->implicit_value(true),
+			 "Enables the libav/libx264 low latncy presets for video encoding.")
 #endif
 			;
 		// clang-format on
@@ -191,6 +193,7 @@ struct VideoOptions : public Options
 	uint32_t segment;
 	size_t circular;
 	uint32_t frames;
+	bool low_latency;
 
 	virtual bool Parse(int argc, char *argv[]) override
 	{

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -80,16 +80,28 @@ void encoderOptionsH264M2M(VideoOptions const *options, AVCodecContext *codec)
 
 void encoderOptionsLibx264(VideoOptions const *options, AVCodecContext *codec)
 {
-	codec->max_b_frames = 1;
 	codec->me_range = 16;
 	codec->me_cmp = 1; // No chroma ME
 	codec->me_subpel_quality = 0;
 	codec->thread_count = 0;
-	codec->thread_type = FF_THREAD_FRAME;
-	codec->slices = 1;
 
-	av_opt_set(codec->priv_data, "preset", "superfast", 0);
-	av_opt_set(codec->priv_data, "partitions", "i8x8,i4x4", 0);
+	if (options->low_latency)
+	{
+		codec->thread_type = FF_THREAD_SLICE;
+		codec->slices = 4;
+		codec->refs = 1;
+		av_opt_set(codec->priv_data, "preset", "ultrafast", 0);
+		av_opt_set(codec->priv_data, "tune", "zerolatency", 0);
+	}
+	else
+	{
+		codec->thread_type = FF_THREAD_FRAME;
+		codec->slices = 1;
+		codec->max_b_frames = 1;
+		av_opt_set(codec->priv_data, "preset", "superfast", 0);
+		av_opt_set(codec->priv_data, "partitions", "i8x8,i4x4", 0);
+	}
+
 	av_opt_set(codec->priv_data, "weightp", "none", 0);
 	av_opt_set(codec->priv_data, "weightb", "0", 0);
 	av_opt_set(codec->priv_data, "motion-est", "dia", 0);


### PR DESCRIPTION
Add a new command line argument (--low-latency) to the video options allowing users to switch on encoder tuning parameters for low latency video encode. Note that this mode will turn down the encoder efficiency by disabling more advanced features, e.g. B-frames.