### PR TITLE
Fix inverted assignment of hef models (8/8L mismatch)

### DIFF
--- a/assets/hailo_yolov8_pose.json
+++ b/assets/hailo_yolov8_pose.json
@@ -11,7 +11,7 @@
 
     "hailo_yolo_pose":
     {
-        "hef_file_8": "/usr/share/hailo-models/yolov8s_pose_h8l_pi.hef",
-        "hef_file_8L": "/usr/share/hailo-models/yolov8s_pose_h8.hef"
+        "hef_file_8": "/usr/share/hailo-models/yolov8s_pose_h8.hef",
+        "hef_file_8L": "/usr/share/hailo-models/yolov8s_pose_h8l_pi.hef"
     }
 }


### PR DESCRIPTION
I recently discovered issues running the examples from the official raspberry pi documentations found here:

[https://www.raspberrypi.com/documentation/computers/ai.html](https://www.raspberrypi.com/documentation/computers/ai.html)

When running the following command, my system complains about HailoRT not being ready:

```
rpicam-hello -t 0 --post-process-file ~/rpicam-apps/assets/hailo_yolov8_pose.json --lores-width 640 --lores-height 640
```

The actual error was the following:

```
[HailoRT] [error] HEF format is not compatible with device. Device arch: HAILO8L, HEF arch: HAILO8
[HailoRT] [error] CHECK_SUCCESS failed with status=HAILO_INVALID_HEF(26)
[HailoRT] [error] CHECK_SUCCESS failed with status=HAILO_INVALID_HEF(26)
[HailoRT] [error] CHECK_SUCCESS failed with status=HAILO_INVALID_HEF(26)
Failed to create configured infer model, status = 26
HailoRT not ready!
```

As you can see in the changed files - there is a mismatch between the Hailo 8 (26 TOPS) and Hailo 8 L (13TOPS). 
It works just fine with those changes. 😊