### PR TITLE
postprocess: hailo: Update for Tappas v3.31.0 API changes.

### DIFF
--- a/post_processing_stages/hailo/hailo_yolo_inference.cpp
+++ b/post_processing_stages/hailo/hailo_yolo_inference.cpp
@@ -19,13 +19,13 @@
 #include "core/rpicam_app.hpp"
 #include "post_processing_stages/object_detect.hpp"
 
-#include "detection/yolo_postprocess.hpp"
+#include "detection/yolo_hailortpp.hpp"
 
 #include "hailo_postprocessing_stage.hpp"
 
 using Size = libcamera::Size;
-using PostProcFuncPtrNms = void (*)(HailoROIPtr, YoloParams *);
-using InitFuncPtr = YoloParams *(*)(std::string, std::string);
+using PostProcFuncPtrNms = void (*)(HailoROIPtr, YoloParamsNMS *);
+using InitFuncPtr = YoloParamsNMS *(*)(std::string, std::string);
 using FreeFuncPtr = void (*)(void *);
 
 using Rectangle = libcamera::Rectangle;
@@ -64,7 +64,7 @@ private:
 	std::vector<LtObject> lt_objects_;
 	std::mutex lock_;
 	PostProcessingLib postproc_nms_;
-	YoloParams *yolo_params_ = nullptr;
+	YoloParamsNMS *yolo_params_ = nullptr;
 
 	// Config params
 	std::string config_path_;

--- a/post_processing_stages/meson.build
+++ b/post_processing_stages/meson.build
@@ -103,7 +103,8 @@ endif
 enable_hailo = false
 hailort_dep = dependency('HailoRT', modules : ['HailoRT::libhailort'], version: '>=4.18.0',
                          required : get_option('enable_hailo'))
-hailo_tappas_dep = dependency('hailo-tappas-core', required : get_option('enable_hailo'))
+hailo_tappas_dep = dependency('hailo-tappas-core', version: '>=3.31.0',
+                              required : get_option('enable_hailo'))
 if hailort_dep.found() and hailo_tappas_dep.found() and opencv_dep.found()
     subdir('hailo')
     enable_hailo = true


### PR DESCRIPTION
The postprocessing libraries have an updated API for init/filter, switch to the new API. Required Hailo Tappas v3.31.0 or later to be installed.