### PR TITLE
Sync fixes

### DIFF
--- a/apps/rpicam_raw.cpp
+++ b/apps/rpicam_raw.cpp
@@ -67,7 +67,12 @@ static void event_loop(LibcameraRaw &app)
 			return;
 		}
 
-		app.EncodeBuffer(std::get<CompletedRequestPtr>(msg.payload), app.RawStream());
+		if (!app.EncodeBuffer(std::get<CompletedRequestPtr>(msg.payload), app.RawStream()))
+		{
+			// Keep advancing our "start time" if we're still waiting to start recording (e.g.
+			// waiting for synchronisation with another camera).
+			start_time = now;
+		}
 	}
 }
 

--- a/apps/rpicam_vid.cpp
+++ b/apps/rpicam_vid.cpp
@@ -118,7 +118,13 @@ static void event_loop(RPiCamEncoder &app)
 			return;
 		}
 		CompletedRequestPtr &completed_request = std::get<CompletedRequestPtr>(msg.payload);
-		app.EncodeBuffer(completed_request, app.VideoStream());
+		if (!app.EncodeBuffer(completed_request, app.VideoStream()))
+		{
+			// Keep advancing our "start time" if we're still waiting to start recording (e.g.
+			// waiting for synchronisation with another camera).
+			start_time = now;
+			count = 0; // reset the "frames encoded" counter too
+		}
 		app.ShowPreview(completed_request, app.VideoStream());
 	}
 }

--- a/encoder/libav_encoder.hpp
+++ b/encoder/libav_encoder.hpp
@@ -77,4 +77,5 @@ private:
 	std::queue<std::unique_ptr<AVDRMFrameDescriptor>> drm_frame_queue_;
 
 	std::string output_file_;
+	bool output_initialised_;
 };


### PR DESCRIPTION
Two changes here:

When using sync mode, only start the timer (or frame counter) when the sychronisation point is reached. This fixes the previously stupid behaviour where the time spent waiting for sync was being included. (Documentation PR will need another update!)

Secondly, fix a crash when using Ctrl-C to quit _before_ the synchronisation point has occurred.

@naushir Could you take a look and merge if happy? Thanks!