### PR TITLE
libav: Use avcodec_get_supported_config instead of deprecated struct …

### DIFF
--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -319,7 +319,13 @@ void LibAvEncoder::initAudioOutCodec(VideoOptions const *options, StreamInfo con
 
 	codec_ctx_[AudioOut]->sample_rate = options->audio_samplerate ? options->audio_samplerate
 																  : stream_[AudioIn]->codecpar->sample_rate;
-	codec_ctx_[AudioOut]->sample_fmt = codec->sample_fmts[0];
+	enum AVSampleFormat **sample_fmts = nullptr;
+	avcodec_get_supported_config(codec_ctx_[AudioOut], codec, AV_CODEC_CONFIG_SAMPLE_FORMAT, 0, (const void **)&sample_fmts, nullptr);
+	if (!sample_fmts)
+		throw std::runtime_error("libav: no supported sample formats for audio codec");
+	else
+		codec_ctx_[AudioOut]->sample_fmt = (*sample_fmts)[0];
+
 	codec_ctx_[AudioOut]->bit_rate = options->audio_bitrate.bps();
 	// usec timebase
 	codec_ctx_[AudioOut]->time_base = { 1, 1000 * 1000 };


### PR DESCRIPTION
Since https://ffmpeg.org/pipermail/ffmpeg-devel/2024-April/325227.html, accessing the `sample_fmts` struct field has been deprecated. This change replaces that with an `avcodec_get_supported_config` call.