### PR TITLE
libav: Use avcodec_get_supported_config instead of deprecated struct …

### DIFF
--- a/encoder/libav_encoder.hpp
+++ b/encoder/libav_encoder.hpp
@@ -18,6 +18,7 @@ extern "C"
 {
 #include "libavcodec/avcodec.h"
 #include "libavcodec/codec_desc.h"
+#include "libavcodec/version.h"
 #include "libavdevice/avdevice.h"
 #include "libavformat/avformat.h"
 #include "libavutil/audio_fifo.h"


### PR DESCRIPTION
…field sample_fmts

Since https://ffmpeg.org/pipermail/ffmpeg-devel/2024-April/325227.html, accessing the sample_fmts struct field has been deprecated. This change replaces that with an avcodec_get_supported_config call.