### PR TITLE
core: Initialise the camera manager from GetCameraManager() if needed

### DIFF
--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -946,8 +946,11 @@ libcamera::Stream *RPiCamApp::GetMainStream() const
 	return nullptr;
 }
 
-const libcamera::CameraManager *RPiCamApp::GetCameraManager() const
+const libcamera::CameraManager *RPiCamApp::GetCameraManager()
 {
+	if (!camera_manager_)
+		initCameraManager();
+
 	return camera_manager_.get();
 }
 

--- a/core/rpicam_app.hpp
+++ b/core/rpicam_app.hpp
@@ -155,7 +155,7 @@ public:
 	Stream *LoresStream(StreamInfo *info = nullptr) const;
 	Stream *GetMainStream() const;
 
-	const CameraManager *GetCameraManager() const;
+	const CameraManager *GetCameraManager();
 	std::vector<std::shared_ptr<libcamera::Camera>> GetCameras()
 	{
 		return GetCameras(camera_manager_.get());


### PR DESCRIPTION
If camera_manager_ has not been initialised, do it before returning the pointer to the caller.