### PR TITLE
WIP: make initCameraManager public

### DIFF
--- a/core/rpicam_app.hpp
+++ b/core/rpicam_app.hpp
@@ -140,6 +140,8 @@ public:
 	void ConfigureVideo(unsigned int flags = FLAG_VIDEO_NONE);
 	void ConfigureZsl(unsigned int still_flags = FLAG_STILL_NONE);
 
+	void initCameraManager();
+
 	void Teardown();
 	void StartCamera();
 	void StopCamera();
@@ -238,7 +240,6 @@ private:
 		Stream *stream;
 	};
 
-	void initCameraManager();
 	void setupCapture();
 	void makeRequests();
 	void queueRequest(CompletedRequest *completed_request);


### PR DESCRIPTION
# Context 
I am controlling the RPi3 camera from a ROS2 node which is making use of the camera for object detection.

However I am not using the cli to set the parameters for the camera (line for raspicam-vid), but rather they are either hard coded or being supplied by a different parsing method from the command line (in this case I am making use of --ros-args, to set parameters specific to the ROS2 node)

I am thus not making use of the Options::Parse method, and have written my own method to set the options for the camera. 
The only challenge I have is that initCameraManager is a private method, and thus I cant setup the camera to make it work. 

Here is small snippet of the code:
```
int main(int argc, char** argv)
{

	RPiCamEncoder app;
	VideoOptions *options = app.GetOptions();
	setupCamera(options, &app);
	options->Print();

	rclcpp::init(argc, argv);
	rclcpp::spin(std::make_shared<Ros2Node>(&app));

...
}


void setupCamera(VideoOptions* options, RPiCamEncoder* app)
{
	using namespace boost::program_options;
	using namespace libcamera;

	// This is to get round the fact that the boost option parser does not
	// allow std::optional types.
	options->framerate = 30.0f;

	// Check if --nopreview is set, and if no info-text string was provided
	// null the defaulted string so nothing gets displayed to stderr.
	options->info_text = "";

	options->nopreview = true;

	// lens_position is even more awkward, because we have two "default"
	// behaviours: Either no lens movement at all (if option is not given),
	// or libcamera's default control value (typically the hyperfocal).
	options->lens_position = 0.0f;

	// Convert time strings to durations
	options->timeout.set("-1.0");
	options->shutter.set("0");
	options->flicker_period.set("0s");
	/*
		options for hdr are: off, single-exp, sensor, auto
	*/
	std::string hdr = "off";

	uint8_t verbose = 2;

	if (hdr != "off" && hdr != "single-exp" && hdr != "sensor" && hdr != "auto")
		throw std::runtime_error("Invalid HDR option provided: " + hdr);

	app->initCameraManager()
...
```

The setupCamera function is very similiar to that of the Option::Parse Method. 

If there is another way of keeping initCameraManager private and also allowing for the above I would be interested in knowing how. 