### PR TITLE
postproc: hailo: Fix for segmentation demo

### DIFF
--- a/assets/hailo_yolov5_segmentation.json
+++ b/assets/hailo_yolov5_segmentation.json
@@ -16,7 +16,7 @@
         "confidence_threshold": 0.4,
 
         "hef_file_8L": "/usr/share/hailo-models/yolov5n_seg_h8l_mz.hef",
-        "hef_file_8": "/usr/share/hailo-models/yolov8m_seg_h8.hef",
+        "hef_file_8": "/usr/share/hailo-models/yolov5n_seg_h8.hef",
         "hailopp_config_file": "/usr/share/hailo-models/yolov5seg.json"
     }
 }

--- a/post_processing_stages/hailo/hailo_yolov5_segmentation.cpp
+++ b/post_processing_stages/hailo/hailo_yolov5_segmentation.cpp
@@ -221,10 +221,10 @@ void YoloSegmentation::Read(boost::property_tree::ptree const &params)
 	confidence_threshold_ = params.get<float>("confidence_threshold", 0.6);
 
 	InitFuncPtr init = reinterpret_cast<InitFuncPtr>(postproc_.GetSymbol("init"));
-	const std::string config_file = params.get<std::string>("hailopp_config_file");
+	const std::string config_file = params.get<std::string>("hailopp_config_file", "");
 	if (init)
 	{
-		if (!fs::exists(config_file))
+		if (!config_file.empty() && !fs::exists(config_file))
 			throw std::runtime_error(std::string("hailo postprocess config file not found: ") + config_file);
 		yolo_params_ = init(config_file, "");
 	}

--- a/post_processing_stages/hailo/meson.build
+++ b/post_processing_stages/hailo/meson.build
@@ -23,6 +23,7 @@ hailo_deps = [hailort_dep, hailo_tappas_dep, libcamera_dep, opencv_dep]
 # Hailo Tappas PP config files to be installed
 hailopp_config_files = files([
     assets_dir / 'yolov5_personface.json',
+    assets_dir / 'yolov5seg.json',
 ])
 
 hailo_postprocessing_src = files([


### PR DESCRIPTION
Switch back to Yolov5 segmentation model.
Allow empty hailort pp file.
Copy the yolov5 pp file to the assets dir.