### PR TITLE
Rpicam detect fix build

### DIFF
--- a/apps/rpicam_detect.cpp
+++ b/apps/rpicam_detect.cpp
@@ -128,7 +128,7 @@ static void event_loop(RPiCamDetectApp &app)
 			else
 				snprintf(filename, sizeof(filename), options->Get().output.c_str(), options->Get().framestart);
 			filename[sizeof(filename) - 1] = 0;
-			options->Get().framestart++;
+			options->Set().framestart++;
 			LOG(1, "Save image " << filename);
 			jpeg_save(mem, info, completed_request->metadata, std::string(filename), app.CameraModel(), options);
 

--- a/apps/rpicam_detect.cpp
+++ b/apps/rpicam_detect.cpp
@@ -82,10 +82,10 @@ static void event_loop(RPiCamDetectApp &app)
 				return;
 
 			std::vector<Detection> detections;
-			bool detected = completed_request->sequence - last_capture_frame >= options->Get().gap &&
+			bool detected = completed_request->sequence - last_capture_frame >= options->gap &&
 							completed_request->post_process_metadata.Get("object_detect.results", detections) == 0 &&
 							std::find_if(detections.begin(), detections.end(), [options](const Detection &d)
-										 { return d.name.find(options->Get().object) != std::string::npos; }) !=
+										 { return d.name.find(options->object) != std::string::npos; }) !=
 								detections.end();
 
 			app.ShowPreview(completed_request, app.ViewfinderStream());
@@ -96,7 +96,7 @@ static void event_loop(RPiCamDetectApp &app)
 				app.Teardown();
 				app.ConfigureStill();
 				app.StartCamera();
-				LOG(1, options->Get().object << " detected");
+				LOG(1, options->object << " detected");
 			}
 		}
 		// In still capture mode, save a jpeg and go back to preview.
@@ -118,7 +118,7 @@ static void event_loop(RPiCamDetectApp &app)
 				std::time(&raw_time);
 				char time_string[32];
 				std::tm *time_info = std::localtime(&raw_time);
-				std::strftime(time_string, sizeof(time_string), options->Get().timeformat.c_str(), time_info);
+				std::strftime(time_string, sizeof(time_string), options->timeformat.c_str(), time_info);
 				snprintf(filename, sizeof(filename), "%s%s.%s", options->Get().output.c_str(), time_string,
 						 options->Get().encoding.c_str());
 			}


### PR DESCRIPTION
was following the guide here: https://www.raspberrypi.com/documentation/computers/camera_software.html#advanced-rpicam-apps with the goal to get the rpicam-apps setup with tensorflow and bumped into a problem where the binaries would not build.

specific command that fails:


You can now build rpicam-apps with the following command:
```bash
meson compile -C build
```


error message:

```bash
../apps/rpicam_detect.cpp:85:108: error: ‘const struct OptsInternal’ has no member named ‘gap’
   85 |                         bool detected = completed_request->sequence - last_capture_frame >= options->Get().gap &&
      |                                                                                                            ^~~
../apps/rpicam_detect.cpp: In lambda function:
../apps/rpicam_detect.cpp:88:118: error: ‘const struct OptsInternal’ has no member named ‘object’
   88 |                                                                                  { return d.name.find(options->Get().object) != std::string::npos; }) !=
      |                                                                                                                      ^~~~~~
In file included from ../core/options.hpp:23,
                 from ../core/still_options.hpp:12,
                 from ../apps/rpicam_detect.cpp:13:
../apps/rpicam_detect.cpp: In function ‘void event_loop(RPiCamDetectApp&)’:
../apps/rpicam_detect.cpp:99:55: error: ‘const struct OptsInternal’ has no member named ‘object’
   99 |                                 LOG(1, options->Get().object << " detected");
      |                                                       ^~~~~~
../core/logging.hpp:7:38: note: in definition of macro ‘LOG’
    7 |                         std::cerr << text << std::endl;                                                                            \
      |                                      ^~~~
../apps/rpicam_detect.cpp:121:96: error: ‘const struct OptsInternal’ has no member named ‘timeformat’; did you mean ‘timeout’?
  121 |                                 std::strftime(time_string, sizeof(time_string), options->Get().timeformat.c_str(), time_info);
      |                                                                                                ^~~~~~~~~~
      |                                                                                                timeout
../apps/rpicam_detect.cpp:131:40: error: increment of member ‘OptsInternal::framestart’ in read-only object
  131 |                         options->Get().framestart++;
      |                         ~~~~~~~~~~~~~~~^~~~~~~~~~
ninja: build stopped: subcommand failed.

```


By no means I am a c++ developer, but with help of some LLMs I was able to identify the problem and patch it.  

Seems that The problem is that the custom fields `(object, gap, timeformat)` are stored directly in DetectOptions, but the code is trying to access them through `options->Get()`, which returns `OptsInternal` that doesn't contain these fields.


this worked locally for me - hopefully it can help fix it :)
