### PR TITLE
core: Add 16-bit modes to the mode_to_pixel_format() helper

### DIFF
--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -41,6 +41,8 @@ static libcamera::PixelFormat mode_to_pixel_format(Mode const &mode)
 		{ Mode(0, 0, 12, true), libcamera::formats::SBGGR12_CSI2P },
 		{ Mode(0, 0, 14, false), libcamera::formats::SBGGR14 },
 		{ Mode(0, 0, 14, true), libcamera::formats::SBGGR14_CSI2P },
+		{ Mode(0, 0, 16, false), libcamera::formats::SBGGR16 },
+		{ Mode(0, 0, 16, true), libcamera::formats::SBGGR16 },
 	};
 
 	auto it = std::find_if(table.begin(), table.end(), [&mode] (auto &m) { return mode.bit_depth == m.first.bit_depth && mode.packed == m.first.packed; });


### PR DESCRIPTION
This was missing from the list. Ensure we handle both "packed" and "unpacked" formats - they are the same for 16-bit modes.