### PR TITLE
options: Remove unused config.h include

### DIFF
--- a/core/options.cpp
+++ b/core/options.cpp
@@ -21,8 +21,6 @@
 
 #include "core/options.hpp"
 
-#include "config.h"
-
 namespace fs = std::filesystem;
 
 namespace

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -23,8 +23,6 @@
 #include "core/logging.hpp"
 #include "core/version.hpp"
 
-#include "config.h"
-
 static constexpr double DEFAULT_FRAMERATE = 30.0;
 
 struct Mode

--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -13,8 +13,6 @@
 
 #include "options.hpp"
 
-#include "config.h"
-
 struct VideoOptions : public Options
 {
 	VideoOptions() : Options()


### PR DESCRIPTION
This include directive is no longer needed in these files.