### PR TITLE
apps: Warn on Pi 5s when still capture will not use temporal denoise

### DIFF
--- a/apps/rpicam_jpeg.cpp
+++ b/apps/rpicam_jpeg.cpp
@@ -102,6 +102,13 @@ int main(int argc, char *argv[])
 			if (options->Get().output.empty())
 				throw std::runtime_error("output file name required");
 
+			if (options->GetPlatform() == Platform::PISP)
+			{
+				LOG_ERROR("WARNING: Capture will not make use of temporal denoise");
+				LOG_ERROR("         Consider using rpicam-still with the --zsl option for best results, for example:");
+				LOG_ERROR("         rpicam-still --zsl -o " << options->Get().output);
+			}
+
 			event_loop(app);
 		}
 	}

--- a/apps/rpicam_still.cpp
+++ b/apps/rpicam_still.cpp
@@ -357,6 +357,13 @@ int main(int argc, char *argv[])
 			if (options->Get().verbose >= 2)
 				options->Get().Print();
 
+			if (options->GetPlatform() == Platform::PISP && !options->Get().zsl)
+			{
+				LOG_ERROR("WARNING: Capture will not make use of temporal denoise");
+				LOG_ERROR("         Consider using the --zsl option for best results, for example:");
+				LOG_ERROR("         rpicam-still --zsl -o " << options->Get().output);
+			}
+
 			event_loop(app);
 		}
 	}


### PR DESCRIPTION
Best denoise results on PiSP platforms should use temporal denoise (TDN). Output an obvious warning when a still capture (rpicam-jpeg or rpicam-still) will not do this and suggest a command line that will.