### PR TITLE
Fix misleading platform detection error for Raspberry Pi 5

### DIFF
--- a/core/options.cpp
+++ b/core/options.cpp
@@ -187,6 +187,8 @@ Platform get_platform()
 			return Platform::VC4;
 		else if (!strncmp((char *)caps.card, "pispbe", sizeof(caps.card)))
 			return Platform::PISP;
+		else if (!strncmp((char *)caps.card, "rp1-cfe", sizeof(caps.card)))
+    			return Platform::PISP;
 		else if (!strncmp((char *)caps.card, "bm2835 mmal", sizeof(caps.card)))
 			return Platform::LEGACY;
 		else


### PR DESCRIPTION
## Description
Fix platform detection for Raspberry Pi 5 by adding support for the 'rp1-cfe' card name to prevent misleading error messages.

## Problem
When Raspberry Pi 5 users encounter camera connection issues, they receive a confusing error message:
ERROR: rpicam-apps currently only supports the Raspberry Pi platforms.

This misleading error suggests that **the platform itself is unsupported**, when the actual issue is usually:
- Camera cable connection problems
- Camera module not properly seated
- Hardware configuration issues

This causes users to waste time investigating platform compatibility instead of checking their hardware setup.

## Root Cause
- The `get_platform()` function in `core/options.cpp` doesn't recognize the 'rp1-cfe' card name used by Raspberry Pi 5
- Raspberry Pi 5 gets detected as `Platform::UNKNOWN`
- rpicam-apps shows platform error instead of more helpful camera detection messages

## Solution
- Add 'rp1-cfe' card name detection to map Raspberry Pi 5 to `Platform::PISP`
- This ensures proper platform detection and allows rpicam-apps to show more accurate error messages
- Users will get clearer feedback about actual hardware issues instead of platform compatibility confusion

## User Experience Impact
**Before this fix:**
- Camera connection issue → "Platform not supported" error
- Users think their Raspberry Pi 5 is incompatible
- Debugging focuses on wrong area (platform vs hardware)

**After this fix:**
- Camera connection issue → Proper camera-related error messages
- Users can focus on actual hardware troubleshooting
- Clear indication that platform is supported

## Testing
- [x] Built successfully on Raspberry Pi 5
- [x] Platform now correctly detected as PISP instead of UNKNOWN
- [x] With proper camera connection: rpicam-apps work normally
- [x] With camera issues: More helpful error messages (not platform errors)
- [x] No impact on other Raspberry Pi models

## Technical Details
- **File modified**: `core/options.cpp`
- **Function**: `get_platform()`
- **Change**: Added `rp1-cfe` → `Platform::PISP` mapping
- **Hardware**: Raspberry Pi 5 uses 'rp1-cfe' driver for camera interface

This small fix significantly improves the debugging experience for Raspberry Pi 5 users by providing accurate error messages that guide them toward the real solution.