### PR TITLE
postprocess: object_detect_udp: Fix compiler warnings and styling

### DIFF
--- a/post_processing_stages/object_detect_udp_stage.cpp
+++ b/post_processing_stages/object_detect_udp_stage.cpp
@@ -51,7 +51,7 @@ private:
 	std::string udp_broadcast_address = "127.0.0.1";
 	u_int16_t udp_broadcast_port = 12345;
 	int sockfd_;
-    struct sockaddr_in servaddr_;
+	struct sockaddr_in servaddr_;
 };
 
 #define NAME "object_detect_udp"
@@ -64,11 +64,11 @@ char const *ObjectDetectUDPStage::Name() const
 
 ObjectDetectUDPStage::~ObjectDetectUDPStage()
 {
-    if (sockfd_ != -1)
-    {
-        close(sockfd_);
-        std::cerr << "UDP socket closed." << std::endl;
-    }
+	if (sockfd_ != -1)
+	{
+		close(sockfd_);
+		std::cerr << "UDP socket closed." << std::endl;
+	}
 }
 
 
@@ -77,30 +77,30 @@ void ObjectDetectUDPStage::Configure()
 	stream_ = app_->GetMainStream();
 	
 	// Initialize UDP socket
-    sockfd_ = socket(AF_INET, SOCK_DGRAM, 0);
-    if (sockfd_ < 0)
-    {
-        perror("UDP socket creation failed");
-        // Handle error, perhaps throw an exception or exit
-        return;
-    }
+	sockfd_ = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sockfd_ < 0)
+	{
+		perror("UDP socket creation failed");
+		// Handle error, perhaps throw an exception or exit
+		return;
+	}
 
-    memset(&servaddr_, 0, sizeof(servaddr_));
+	memset(&servaddr_, 0, sizeof(servaddr_));
 
-    // Filling server information
-    servaddr_.sin_family = AF_INET;
-    servaddr_.sin_port = htons(udp_broadcast_port);
-    if (inet_pton(AF_INET, udp_broadcast_address.c_str(), &servaddr_.sin_addr) <= 0)
-    {
-        perror("Invalid address/ Address not supported");
-        close(sockfd_);
-        sockfd_ = -1; // Mark as invalid
-        return;
-    }
+	// Filling server information
+	servaddr_.sin_family = AF_INET;
+	servaddr_.sin_port = htons(udp_broadcast_port);
+	if (inet_pton(AF_INET, udp_broadcast_address.c_str(), &servaddr_.sin_addr) <= 0)
+	{
+		perror("Invalid address/ Address not supported");
+		close(sockfd_);
+		sockfd_ = -1; // Mark as invalid
+		return;
+	}
 
-    std::cerr << "UDP socket initialized for IP: " << udp_broadcast_address << ", Port: " << udp_broadcast_port << std::endl;
+	std::cerr
+		<< "UDP socket initialized for IP: " << udp_broadcast_address << ", Port: " << udp_broadcast_port << std::endl;
 }
-
 
 void ObjectDetectUDPStage::Read(boost::property_tree::ptree const &params)
 {
@@ -108,61 +108,66 @@ void ObjectDetectUDPStage::Read(boost::property_tree::ptree const &params)
 	udp_broadcast_port = params.get<u_int16_t>("port", UDP_PORT);
 }
 
+template <typename T>
+void append(std::vector<char> &buffer, const T &value)
+{
+	const char *raw = reinterpret_cast<const char *>(&value);
+	buffer.insert(buffer.end(), raw, raw + sizeof(T));
+}
+
 bool ObjectDetectUDPStage::Process(CompletedRequestPtr &completed_request)
 {
 	if (!stream_)
-        return false;
+		return false;
 
-    std::vector<Detection> detections;
-    completed_request->post_process_metadata.Get("object_detect.results", detections);
+	std::vector<Detection> detections;
+	completed_request->post_process_metadata.Get("object_detect.results", detections);
 
-    if (sockfd_ == -1)
-        return false;
+	if (sockfd_ == -1)
+		return false;
 
-    for (auto &detection : detections)
+	for (auto &detection : detections)
 	{
-        // Draw rectangle and text on the image
-        std::stringstream text_stream;
-        text_stream << detection.name << " " << (int)(detection.confidence * 100) << "%";
-        std::string text = text_stream.str();
+		// Draw rectangle and text on the image
+		std::stringstream text_stream;
+		text_stream << detection.name << " " << (int)(detection.confidence * 100) << "%";
+		std::string text = text_stream.str();
 		
-        // Use a vector to dynamically build the binary message
-        std::vector<char> udp_data_buffer;
+		// Use a vector to dynamically build the binary message
+		std::vector<char> udp_data_buffer;
 
-        // 1. Add start delimiter (4 bytes)
-        udp_data_buffer.insert(udp_data_buffer.end(), (char*)&START_DELIMITER, (char*)&START_DELIMITER + sizeof(START_DELIMITER));
+		// 1. Add start delimiter (4 bytes)
+		append(udp_data_buffer, START_DELIMITER);
 
-        // 2. Add x, y, width, height (4 bytes each)
-        const int32_t x = detection.box.x;
-        const int32_t y = detection.box.y;
-        const int32_t width = detection.box.width;
-        const int32_t height = detection.box.height;
-        udp_data_buffer.insert(udp_data_buffer.end(), (char*)&x, (char*)&x + sizeof(x));
-        udp_data_buffer.insert(udp_data_buffer.end(), (char*)&y, (char*)&y + sizeof(y));
-        udp_data_buffer.insert(udp_data_buffer.end(), (char*)&width, (char*)&width + sizeof(width));
-        udp_data_buffer.insert(udp_data_buffer.end(), (char*)&height, (char*)&height + sizeof(height));
+		// 2. Add x, y, width, height (4 bytes each)
+		const int32_t x = detection.box.x;
+		const int32_t y = detection.box.y;
+		const int32_t width = detection.box.width;
+		const int32_t height = detection.box.height;
 
-        // 3. Add name length and name string
-        uint32_t name_length = detection.name.length();
-        if (name_length > 255) {
-            // Truncate or handle error for names longer than 255 chars
-            name_length = 255;
-        }
-        udp_data_buffer.push_back(name_length);
-        udp_data_buffer.insert(udp_data_buffer.end(), detection.name.begin(), detection.name.begin() + name_length);
+		append(udp_data_buffer, x);
+		append(udp_data_buffer, y);
+		append(udp_data_buffer, width);
+		append(udp_data_buffer, height);
 
-        // 4. Add confidence (4 bytes)
-        const float confidence = detection.confidence;
-        udp_data_buffer.insert(udp_data_buffer.end(), (char*)&confidence, (char*)&confidence + sizeof(confidence));
+		// 3. Add name length and name string
+		constexpr uint8_t name_length = 255;
+		udp_data_buffer.push_back(static_cast<char>(name_length));
 
-        // Send data via UDP
-        const ssize_t bytes_sent = sendto(sockfd_, udp_data_buffer.data(), udp_data_buffer.size(), 0,
-                                        (const struct sockaddr *)&servaddr_, sizeof(servaddr_));
-        if (bytes_sent < 0)
-        {
-            perror("Failed to send UDP message");
-        }
+		uint8_t name[name_length];
+		memcpy(name, detection.name.c_str(), name_length - 2);
+		name[name_length - 1] = '\0';
+		append(udp_data_buffer, name);
 
+		// 4. Add confidence (4 bytes)
+		const float confidence = detection.confidence;
+		append(udp_data_buffer, confidence);
+
+		// Send data via UDP
+		const ssize_t bytes_sent = sendto(sockfd_, udp_data_buffer.data(), udp_data_buffer.size(), 0,
+										  (const struct sockaddr *)&servaddr_, sizeof(servaddr_));
+		if (bytes_sent < 0)
+			perror("Failed to send UDP message");
 	}
 
 	return false;


### PR DESCRIPTION
gcc 14 was throwing false positives about possible buffer overflows when populating the udp_data_buffer.  Fix this by refactoring the code to be more explicit with the memcpy.

Also fix some styling issues with the source file.