### PR TITLE
postprocessing: segmentation: add missing header

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,36 @@ Build
 -----
 For usage and build instructions, see the official Raspberry Pi documentation pages [here.](https://www.raspberrypi.com/documentation/computers/camera_software.html#building-libcamera-and-rpicam-apps)
 
+GUI Application
+---------------
+
+`rpicam-gui` provides a Qt-based interface for configuring and controlling libcamera captures. The window presents a live preview alongside controls for adjusting still and video settings such as resolution, framerate, still encodings, video codecs, bitrate and output locations. Capture buttons trigger still image saves or start and stop video recordings using the existing option structures provided by the command-line tools.
+
+To build the GUI you must enable Qt support when configuring the project:
+
+```
+meson setup build -Denable_qt=true
+ninja -C build
+```
+
+### Raspberry Pi OS (Pi 4B) notes
+
+1. Install the Qt development dependencies:
+
+   ```
+   sudo apt update
+   sudo apt install qtbase5-dev qtdeclarative5-dev
+   ```
+
+2. Configure and build the applications with Qt support as shown above. The build will produce the `rpicam-gui` executable alongside the existing command-line tools.
+3. Launch the GUI with:
+
+   ```
+   ./build/apps/rpicam-gui
+   ```
+
+   Use the preview pane to frame the scene, adjust camera parameters from the settings panel, and press **Capture Photo** or **Start Video** to create still images or video clips.
+
 License
 -------
 

--- a/apps/meson.build
+++ b/apps/meson.build
@@ -35,3 +35,12 @@ if enable_tflite
                                link_with : rpicam_app,
                                install : true)
 endif
+
+if enable_qt
+    gui_moc = qt5_mod.preprocess(moc_sources : ['rpicam_gui.cpp'])
+    rpicam_gui = executable('rpicam-gui', ['rpicam_gui.cpp'] + gui_moc,
+                            include_directories : include_directories('..'),
+                            dependencies: [libcamera_dep, boost_dep, qt_dep],
+                            link_with : rpicam_app,
+                            install : true)
+endif

--- a/apps/rpicam_gui.cpp
+++ b/apps/rpicam_gui.cpp
@@ -1,0 +1,766 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * rpicam_gui.cpp - Qt based GUI application for Raspberry Pi cameras.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <ctime>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <QApplication>
+#include <QComboBox>
+#include <QCloseEvent>
+#include <QDoubleSpinBox>
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMainWindow>
+#include <QMessageBox>
+#include <QObject>
+#include <QPushButton>
+#include <QString>
+#include <QSpinBox>
+#include <QStatusBar>
+#include <QThread>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include "core/frame_info.hpp"
+#include "core/rpicam_app.hpp"
+#include "core/rpicam_encoder.hpp"
+#include "core/still_options.hpp"
+#include "core/video_options.hpp"
+
+#include "image/image.hpp"
+
+#include "output/output.hpp"
+
+#include "preview/qt_preview.hpp"
+
+using namespace std::chrono_literals;
+using namespace std::placeholders;
+namespace fs = std::filesystem;
+
+class RPiCamStillApp : public RPiCamApp
+{
+public:
+        RPiCamStillApp() : RPiCamApp(std::make_unique<StillOptions>()) {}
+
+        StillOptions *GetOptions() const { return static_cast<StillOptions *>(RPiCamApp::GetOptions()); }
+};
+
+static std::string generate_filename(StillOptions const *options)
+{
+        char filename[128];
+        std::string folder = options->Get().output;
+        if (!folder.empty() && folder.back() != '/')
+                folder += "/";
+        if (options->Get().datetime)
+        {
+                std::time_t raw_time;
+                std::time(&raw_time);
+                char time_string[32];
+                std::tm *time_info = std::localtime(&raw_time);
+                std::strftime(time_string, sizeof(time_string), "%m%d%H%M%S", time_info);
+                snprintf(filename, sizeof(filename), "%s%s.%s", folder.c_str(), time_string, options->Get().encoding.c_str());
+        }
+        else if (options->Get().timestamp)
+                snprintf(filename, sizeof(filename), "%s%u.%s", folder.c_str(), (unsigned)time(NULL), options->Get().encoding.c_str());
+        else if (!options->Get().output.empty())
+                snprintf(filename, sizeof(filename), options->Get().output.c_str(), options->Get().framestart);
+        else
+                snprintf(filename, sizeof(filename), "capture_%u.%s", options->Get().framestart, options->Get().encoding.c_str());
+        filename[sizeof(filename) - 1] = 0;
+        return std::string(filename);
+}
+
+static void update_latest_link(std::string const &filename, StillOptions const *options)
+{
+        if (!options->Get().latest.empty())
+        {
+                fs::path link { options->Get().latest };
+                fs::path target { filename };
+                if (fs::exists(link) && !fs::remove(link))
+                        LOG_ERROR("WARNING: could not delete latest link " << options->Get().latest);
+                else
+                {
+                        fs::create_symlink(target, link);
+                        LOG(2, "Link " << options->Get().latest << " created");
+                }
+        }
+}
+
+static std::string save_image(RPiCamStillApp &app, CompletedRequestPtr &payload, libcamera::Stream *stream,
+                                                        std::string const &filename)
+{
+        StillOptions const *options = app.GetOptions();
+        StreamInfo info = app.GetStreamInfo(stream);
+        BufferReadSync r(&app, payload->buffers[stream]);
+        const std::vector<libcamera::Span<uint8_t>> mem = r.Get();
+        if (stream == app.RawStream())
+                dng_save(mem, info, payload->metadata, filename, app.CameraModel(), options);
+        else if (options->Get().encoding == "jpg")
+                jpeg_save(mem, info, payload->metadata, filename, app.CameraModel(), options);
+        else if (options->Get().encoding == "png")
+                png_save(mem, info, filename, options);
+        else if (options->Get().encoding == "bmp")
+                bmp_save(mem, info, filename, options);
+        else
+                yuv_save(mem, info, filename, options);
+        LOG(2, "Saved image " << info.width << " x " << info.height << " to file " << filename);
+        return filename;
+}
+
+static std::vector<std::string> save_images(RPiCamStillApp &app, CompletedRequestPtr &payload)
+{
+        StillOptions *options = app.GetOptions();
+        std::vector<std::string> paths;
+        std::string filename = generate_filename(options);
+        paths.push_back(save_image(app, payload, app.StillStream(), filename));
+        update_latest_link(filename, options);
+        if (options->Get().raw)
+        {
+                filename = filename.substr(0, filename.rfind('.')) + ".dng";
+                paths.push_back(save_image(app, payload, app.RawStream(), filename));
+        }
+        options->Set().framestart++;
+        if (options->Get().wrap)
+                options->Set().framestart %= options->Get().wrap;
+        return paths;
+}
+
+static int get_colourspace_flags(const std::string &codec)
+{
+        if (codec == "mjpeg" || codec == "yuv420")
+                return RPiCamEncoder::FLAG_VIDEO_JPEG_COLOURSPACE;
+        return RPiCamEncoder::FLAG_VIDEO_NONE;
+}
+
+class CameraWorker : public QObject
+{
+        Q_OBJECT
+
+public:
+        CameraWorker()
+        {
+                still_options_ = still_app_.GetOptions();
+                still_options_->Set().qt_preview = true;
+                still_options_->Set().nopreview = false;
+                still_options_->Set().encoding = "jpg";
+                still_options_->Set().codec = "h264";
+                still_options_->Set().bitrate.set("10mbps");
+        }
+
+        ~CameraWorker()
+        {
+                shutdown();
+        }
+
+public slots:
+        void initialize() {}
+
+        void shutdown()
+        {
+                if (video_thread_.joinable())
+                {
+                        video_stop_requested_ = true;
+                        RPiCamApp::MsgType t = RPiCamApp::MsgType::Quit;
+                        RPiCamApp::MsgPayload payload;
+                        if (encoder_)
+                                encoder_->PostMessage(t, payload);
+                        video_thread_.join();
+                }
+                if (encoder_)
+                {
+                        encoder_->StopCamera();
+                        encoder_->StopEncoder();
+                        encoder_->Teardown();
+                        encoder_->CloseCamera();
+                        encoder_.reset();
+                        video_output_.reset();
+                }
+                if (preview_active_)
+                {
+                        still_app_.StopCamera();
+                        still_app_.Teardown();
+                        preview_active_ = false;
+                }
+                if (camera_open_)
+                {
+                        still_app_.CloseCamera();
+                        camera_open_ = false;
+                }
+        }
+
+        void startPreview()
+        {
+                try
+                {
+                        if (!camera_open_)
+                        {
+                                still_app_.OpenCamera();
+                                camera_open_ = true;
+                        }
+                        still_app_.ConfigureViewfinder();
+                        still_app_.StartCamera();
+                        preview_active_ = true;
+                        emit previewStarted();
+                        emit statusMessage("Preview running");
+                }
+                catch (std::exception const &e)
+                {
+                        emit errorOccurred(QString::fromStdString(e.what()));
+                }
+        }
+
+        void stopPreview()
+        {
+                try
+                {
+                        if (preview_active_)
+                        {
+                                still_app_.StopCamera();
+                                still_app_.Teardown();
+                                preview_active_ = false;
+                                emit previewStopped();
+                                emit statusMessage("Preview stopped");
+                        }
+                }
+                catch (std::exception const &e)
+                {
+                        emit errorOccurred(QString::fromStdString(e.what()));
+                }
+        }
+
+        void updateResolution(int width, int height)
+        {
+                still_options_->Set().width = width;
+                still_options_->Set().height = height;
+        }
+
+        void updateFramerate(double fps)
+        {
+                if (fps <= 0.0)
+                        still_options_->Set().framerate.reset();
+                else
+                        still_options_->Set().framerate = static_cast<float>(fps);
+        }
+
+        void updateStillEncoding(const QString &encoding)
+        {
+                still_options_->Set().encoding = encoding.toStdString();
+        }
+
+        void updateVideoCodec(const QString &codec)
+        {
+                still_options_->Set().codec = codec.toStdString();
+        }
+
+        void updateVideoBitrate(int kbps)
+        {
+                still_options_->Set().bitrate.set(std::to_string(kbps) + "kbps");
+        }
+
+        void setStillOutput(const QString &path)
+        {
+                still_options_->Set().output = path.toStdString();
+        }
+
+        void setVideoOutput(const QString &path)
+        {
+                video_output_path_ = path.toStdString();
+        }
+
+        void captureStill()
+        {
+                try
+                {
+                        unsigned int flags = RPiCamApp::FLAG_STILL_NONE;
+                        std::string encoding = still_options_->Get().encoding;
+                        if (encoding == "rgb24" || encoding == "png")
+                                flags |= RPiCamApp::FLAG_STILL_BGR;
+                        if (encoding == "rgb48")
+                                flags |= RPiCamApp::FLAG_STILL_BGR48;
+                        else if (encoding == "bmp")
+                                flags |= RPiCamApp::FLAG_STILL_RGB;
+                        if (still_options_->Get().raw)
+                                flags |= RPiCamApp::FLAG_STILL_RAW;
+
+                        bool resume_preview = preview_active_;
+                        if (preview_active_)
+                        {
+                                still_app_.StopCamera();
+                                still_app_.Teardown();
+                                preview_active_ = false;
+                        }
+
+                        still_app_.ConfigureStill(flags);
+                        still_app_.StartCamera();
+
+                        std::vector<std::string> captured_paths;
+                        while (true)
+                        {
+                                RPiCamApp::Msg msg = still_app_.Wait();
+                                if (msg.type == RPiCamApp::MsgType::Timeout)
+                                {
+                                        still_app_.StopCamera();
+                                        still_app_.StartCamera();
+                                        continue;
+                                }
+                                if (msg.type == RPiCamApp::MsgType::Quit)
+                                        throw std::runtime_error("Preview window closed");
+                                if (msg.type == RPiCamApp::MsgType::RequestComplete)
+                                {
+                                        CompletedRequestPtr payload = std::get<CompletedRequestPtr>(msg.payload);
+                                        captured_paths = save_images(still_app_, payload);
+                                        break;
+                                }
+                        }
+
+                        still_app_.StopCamera();
+                        still_app_.Teardown();
+
+                        if (resume_preview)
+                        {
+                                still_app_.ConfigureViewfinder();
+                                still_app_.StartCamera();
+                                preview_active_ = true;
+                                emit previewStarted();
+                        }
+
+                        if (!captured_paths.empty())
+                        {
+                                emit stillCaptured(QString::fromStdString(captured_paths.front()));
+                                emit statusMessage(QStringLiteral("Still captured: %1").arg(QString::fromStdString(captured_paths.front())));
+                        }
+                }
+                catch (std::exception const &e)
+                {
+                        emit errorOccurred(QString::fromStdString(e.what()));
+                }
+        }
+
+        void startVideo()
+        {
+                try
+                {
+                        if (video_thread_.joinable())
+                                return;
+
+                        if (preview_active_)
+                        {
+                                still_app_.StopCamera();
+                                still_app_.Teardown();
+                                preview_active_ = false;
+                        }
+
+                        encoder_ = std::make_unique<RPiCamEncoder>();
+                        VideoOptions *video_opts = encoder_->GetOptions();
+                        video_opts->Set() = still_options_->Get();
+                        video_opts->Set().output = video_output_path_;
+                        if (video_opts->Get().output.empty())
+                                video_opts->Set().output = "video.h264";
+
+                        video_output_ = std::unique_ptr<Output>(Output::Create(video_opts));
+                        encoder_->SetEncodeOutputReadyCallback(std::bind(&Output::OutputReady, video_output_.get(), _1, _2, _3, _4));
+                        encoder_->SetMetadataReadyCallback(std::bind(&Output::MetadataReady, video_output_.get(), _1));
+
+                        encoder_->OpenCamera();
+                        encoder_->ConfigureVideo(get_colourspace_flags(video_opts->Get().codec));
+                        encoder_->StartEncoder();
+                        encoder_->StartCamera();
+
+                        video_stop_requested_ = false;
+                        video_thread_ = std::thread(&CameraWorker::videoLoop, this);
+                        emit videoStarted(QString::fromStdString(video_opts->Get().output));
+                        emit statusMessage(QStringLiteral("Recording video to %1").arg(QString::fromStdString(video_opts->Get().output)));
+                }
+                catch (std::exception const &e)
+                {
+                        emit errorOccurred(QString::fromStdString(e.what()));
+                }
+        }
+
+        void stopVideo()
+        {
+                if (!encoder_)
+                        return;
+
+                video_stop_requested_ = true;
+                RPiCamApp::MsgType t = RPiCamApp::MsgType::Quit;
+                RPiCamApp::MsgPayload payload;
+                encoder_->PostMessage(t, payload);
+                if (video_thread_.joinable())
+                        video_thread_.join();
+
+                encoder_->StopCamera();
+                encoder_->StopEncoder();
+                encoder_->Teardown();
+                encoder_->CloseCamera();
+                emit videoStopped(QString::fromStdString(encoder_->GetOptions()->Get().output));
+                emit statusMessage("Video recording stopped");
+
+                encoder_.reset();
+                video_output_.reset();
+        }
+
+signals:
+        void previewStarted();
+        void previewStopped();
+        void stillCaptured(const QString &path);
+        void videoStarted(const QString &path);
+        void videoStopped(const QString &path);
+        void statusMessage(const QString &message);
+        void errorOccurred(const QString &message);
+
+private:
+        void videoLoop()
+        {
+                Stream *video_stream = encoder_->VideoStream();
+                while (!video_stop_requested_)
+                {
+                        RPiCamEncoder::Msg msg = encoder_->Wait();
+                        if (video_stop_requested_)
+                                break;
+                        if (msg.type == RPiCamApp::MsgType::Timeout)
+                        {
+                                encoder_->StopCamera();
+                                encoder_->StartCamera();
+                                continue;
+                        }
+                        if (msg.type == RPiCamApp::MsgType::Quit)
+                                break;
+                        if (msg.type != RPiCamApp::MsgType::RequestComplete)
+                                continue;
+                        CompletedRequestPtr payload = std::get<CompletedRequestPtr>(msg.payload);
+                        encoder_->EncodeBuffer(payload, video_stream);
+                }
+        }
+
+        RPiCamStillApp still_app_;
+        StillOptions *still_options_ = nullptr;
+        bool camera_open_ = false;
+        bool preview_active_ = false;
+        std::unique_ptr<RPiCamEncoder> encoder_;
+        std::unique_ptr<Output> video_output_;
+        std::thread video_thread_;
+        std::atomic<bool> video_stop_requested_ { false };
+        std::string video_output_path_;
+};
+
+class MainWindow : public QMainWindow
+{
+        Q_OBJECT
+
+public:
+        MainWindow()
+        {
+                worker_ = new CameraWorker();
+                worker_->moveToThread(&worker_thread_);
+                connect(&worker_thread_, &QThread::finished, worker_, &QObject::deleteLater);
+                worker_thread_.start();
+                QMetaObject::invokeMethod(worker_, "initialize", Qt::QueuedConnection);
+
+                createUi();
+                connectSignals();
+        }
+
+        ~MainWindow()
+        {
+                worker_thread_.quit();
+                worker_thread_.wait();
+        }
+
+protected:
+        void closeEvent(QCloseEvent *event) override
+        {
+                QMetaObject::invokeMethod(worker_, "shutdown", Qt::BlockingQueuedConnection);
+                worker_thread_.quit();
+                worker_thread_.wait();
+                QMainWindow::closeEvent(event);
+        }
+
+private:
+        void createUi()
+        {
+                QWidget *central = new QWidget(this);
+                setCentralWidget(central);
+
+                auto *main_layout = new QHBoxLayout(central);
+                preview_container_ = new QWidget(central);
+                preview_container_->setObjectName("previewContainer");
+                preview_container_->setMinimumSize(640, 480);
+                preview_container_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+                main_layout->addWidget(preview_container_, 3);
+
+                auto *control_layout = new QVBoxLayout();
+                main_layout->addLayout(control_layout, 2);
+
+                auto *capture_group = new QGroupBox(tr("Capture"), central);
+                auto *capture_layout = new QVBoxLayout(capture_group);
+
+                start_preview_button_ = new QPushButton(tr("Start Preview"), capture_group);
+                stop_preview_button_ = new QPushButton(tr("Stop Preview"), capture_group);
+                capture_button_ = new QPushButton(tr("Capture Photo"), capture_group);
+                start_video_button_ = new QPushButton(tr("Start Video"), capture_group);
+                stop_video_button_ = new QPushButton(tr("Stop Video"), capture_group);
+                stop_preview_button_->setEnabled(false);
+                stop_video_button_->setEnabled(false);
+
+                auto *still_output_layout = new QHBoxLayout();
+                still_output_edit_ = new QLineEdit(capture_group);
+                still_output_edit_->setPlaceholderText(tr("Filename or pattern (e.g. image%04u.jpg)"));
+                auto *still_browse = new QPushButton(tr("Browse"), capture_group);
+                still_output_layout->addWidget(still_output_edit_);
+                still_output_layout->addWidget(still_browse);
+
+                auto *video_output_layout = new QHBoxLayout();
+                video_output_edit_ = new QLineEdit(capture_group);
+                video_output_edit_->setPlaceholderText(tr("Video file (e.g. clip.h264)"));
+                auto *video_browse = new QPushButton(tr("Browse"), capture_group);
+                video_output_layout->addWidget(video_output_edit_);
+                video_output_layout->addWidget(video_browse);
+
+                capture_layout->addWidget(start_preview_button_);
+                capture_layout->addWidget(stop_preview_button_);
+                capture_layout->addWidget(capture_button_);
+                capture_layout->addWidget(start_video_button_);
+                capture_layout->addWidget(stop_video_button_);
+                capture_layout->addWidget(new QLabel(tr("Still output"), capture_group));
+                capture_layout->addLayout(still_output_layout);
+                capture_layout->addWidget(new QLabel(tr("Video output"), capture_group));
+                capture_layout->addLayout(video_output_layout);
+
+                control_layout->addWidget(capture_group);
+
+                auto *settings_group = new QGroupBox(tr("Settings"), central);
+                auto *settings_form = new QFormLayout(settings_group);
+
+                width_spin_ = new QSpinBox(settings_group);
+                width_spin_->setRange(0, 8000);
+                width_spin_->setValue(0);
+                height_spin_ = new QSpinBox(settings_group);
+                height_spin_->setRange(0, 8000);
+                height_spin_->setValue(0);
+                framerate_spin_ = new QDoubleSpinBox(settings_group);
+                framerate_spin_->setRange(0.0, 120.0);
+                framerate_spin_->setDecimals(2);
+                framerate_spin_->setSingleStep(1.0);
+                framerate_spin_->setValue(30.0);
+                encoding_combo_ = new QComboBox(settings_group);
+                encoding_combo_->addItems({ "jpg", "png", "bmp", "yuv420" });
+                codec_combo_ = new QComboBox(settings_group);
+                codec_combo_->addItems({ "h264", "mjpeg", "yuv420" });
+                bitrate_combo_ = new QComboBox(settings_group);
+                bitrate_combo_->addItem("5 Mbps", 5000);
+                bitrate_combo_->addItem("10 Mbps", 10000);
+                bitrate_combo_->addItem("20 Mbps", 20000);
+                bitrate_combo_->setCurrentIndex(1);
+
+                settings_form->addRow(tr("Width"), width_spin_);
+                settings_form->addRow(tr("Height"), height_spin_);
+                settings_form->addRow(tr("Framerate"), framerate_spin_);
+                settings_form->addRow(tr("Still encoding"), encoding_combo_);
+                settings_form->addRow(tr("Video codec"), codec_combo_);
+                settings_form->addRow(tr("Video bitrate"), bitrate_combo_);
+
+                control_layout->addWidget(settings_group);
+                control_layout->addStretch(1);
+
+                status_label_ = new QLabel(tr("Ready"), central);
+                statusBar()->addPermanentWidget(status_label_, 1);
+
+                connect(still_browse, &QPushButton::clicked, this, &MainWindow::chooseStillOutput);
+                connect(video_browse, &QPushButton::clicked, this, &MainWindow::chooseVideoOutput);
+        }
+
+        void connectSignals()
+        {
+                connect(start_preview_button_, &QPushButton::clicked, this, &MainWindow::startPreview);
+                connect(stop_preview_button_, &QPushButton::clicked, this, &MainWindow::stopPreview);
+                connect(capture_button_, &QPushButton::clicked, this, &MainWindow::captureStill);
+                connect(start_video_button_, &QPushButton::clicked, this, &MainWindow::startVideo);
+                connect(stop_video_button_, &QPushButton::clicked, this, &MainWindow::stopVideo);
+
+                connect(width_spin_, qOverload<int>(&QSpinBox::valueChanged), this, &MainWindow::updateResolution);
+                connect(height_spin_, qOverload<int>(&QSpinBox::valueChanged), this, &MainWindow::updateResolution);
+                connect(framerate_spin_, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &MainWindow::updateFramerate);
+                connect(encoding_combo_, &QComboBox::currentTextChanged, this, &MainWindow::updateStillEncoding);
+                connect(codec_combo_, &QComboBox::currentTextChanged, this, &MainWindow::updateVideoCodec);
+                connect(bitrate_combo_, &QComboBox::currentIndexChanged, this, &MainWindow::updateBitrate);
+
+                connect(worker_, &CameraWorker::previewStarted, this, &MainWindow::onPreviewStarted);
+                connect(worker_, &CameraWorker::previewStopped, this, &MainWindow::onPreviewStopped);
+                connect(worker_, &CameraWorker::stillCaptured, this, &MainWindow::onStillCaptured);
+                connect(worker_, &CameraWorker::videoStarted, this, &MainWindow::onVideoStarted);
+                connect(worker_, &CameraWorker::videoStopped, this, &MainWindow::onVideoStopped);
+                connect(worker_, &CameraWorker::statusMessage, this, &MainWindow::onStatusMessage);
+                connect(worker_, &CameraWorker::errorOccurred, this, &MainWindow::onError);
+
+                updateResolution();
+                updateFramerate(framerate_spin_->value());
+                updateStillEncoding(encoding_combo_->currentText());
+                updateVideoCodec(codec_combo_->currentText());
+                updateBitrate(bitrate_combo_->currentIndex());
+        }
+
+        void startPreview()
+        {
+                QtPreview::RegisterPreviewParent(preview_container_);
+                QMetaObject::invokeMethod(worker_, "startPreview", Qt::QueuedConnection);
+                start_preview_button_->setEnabled(false);
+                stop_preview_button_->setEnabled(true);
+        }
+
+        void stopPreview()
+        {
+                QMetaObject::invokeMethod(worker_, "stopPreview", Qt::QueuedConnection);
+        }
+
+        void captureStill()
+        {
+                QMetaObject::invokeMethod(worker_, "setStillOutput", Qt::QueuedConnection,
+                                          Q_ARG(QString, still_output_edit_->text()));
+                QMetaObject::invokeMethod(worker_, "captureStill", Qt::QueuedConnection);
+        }
+
+        void startVideo()
+        {
+                QMetaObject::invokeMethod(worker_, "setVideoOutput", Qt::QueuedConnection,
+                                          Q_ARG(QString, video_output_edit_->text()));
+                QMetaObject::invokeMethod(worker_, "startVideo", Qt::QueuedConnection);
+                start_video_button_->setEnabled(false);
+                stop_video_button_->setEnabled(true);
+                start_preview_button_->setEnabled(false);
+                stop_preview_button_->setEnabled(false);
+        }
+
+        void stopVideo()
+        {
+                QMetaObject::invokeMethod(worker_, "stopVideo", Qt::QueuedConnection);
+        }
+
+        void chooseStillOutput()
+        {
+                QString path = QFileDialog::getSaveFileName(this, tr("Select still output"), still_output_edit_->text());
+                if (!path.isEmpty())
+                        still_output_edit_->setText(path);
+        }
+
+        void chooseVideoOutput()
+        {
+                QString path = QFileDialog::getSaveFileName(this, tr("Select video output"), video_output_edit_->text());
+                if (!path.isEmpty())
+                        video_output_edit_->setText(path);
+        }
+
+        void updateResolution()
+        {
+                QMetaObject::invokeMethod(worker_, "updateResolution", Qt::QueuedConnection,
+                                          Q_ARG(int, width_spin_->value()), Q_ARG(int, height_spin_->value()));
+        }
+
+        void updateFramerate(double value)
+        {
+                QMetaObject::invokeMethod(worker_, "updateFramerate", Qt::QueuedConnection, Q_ARG(double, value));
+        }
+
+        void updateStillEncoding(const QString &encoding)
+        {
+                QMetaObject::invokeMethod(worker_, "updateStillEncoding", Qt::QueuedConnection, Q_ARG(QString, encoding));
+        }
+
+        void updateVideoCodec(const QString &codec)
+        {
+                QMetaObject::invokeMethod(worker_, "updateVideoCodec", Qt::QueuedConnection, Q_ARG(QString, codec));
+        }
+
+        void updateBitrate(int index)
+        {
+                int kbps = bitrate_combo_->itemData(index).toInt();
+                QMetaObject::invokeMethod(worker_, "updateVideoBitrate", Qt::QueuedConnection, Q_ARG(int, kbps));
+        }
+
+        void onPreviewStarted()
+        {
+                start_preview_button_->setEnabled(false);
+                stop_preview_button_->setEnabled(true);
+        }
+
+        void onPreviewStopped()
+        {
+                start_preview_button_->setEnabled(true);
+                stop_preview_button_->setEnabled(false);
+        }
+
+        void onStillCaptured(const QString &path)
+        {
+                QMessageBox::information(this, tr("Capture complete"), tr("Saved still to %1").arg(path));
+        }
+
+        void onVideoStarted(const QString &path)
+        {
+                QMessageBox::information(this, tr("Video recording"), tr("Recording to %1").arg(path));
+        }
+
+        void onVideoStopped(const QString &path)
+        {
+                start_video_button_->setEnabled(true);
+                stop_video_button_->setEnabled(false);
+                start_preview_button_->setEnabled(true);
+                stop_preview_button_->setEnabled(false);
+                QMessageBox::information(this, tr("Recording stopped"), tr("Saved video to %1").arg(path));
+        }
+
+        void onStatusMessage(const QString &message)
+        {
+                status_label_->setText(message);
+        }
+
+        void onError(const QString &message)
+        {
+                QMessageBox::critical(this, tr("Camera error"), message);
+                status_label_->setText(message);
+                start_preview_button_->setEnabled(true);
+                stop_preview_button_->setEnabled(false);
+                start_video_button_->setEnabled(true);
+                stop_video_button_->setEnabled(false);
+        }
+
+        CameraWorker *worker_ = nullptr;
+        QThread worker_thread_;
+        QWidget *preview_container_ = nullptr;
+        QPushButton *start_preview_button_ = nullptr;
+        QPushButton *stop_preview_button_ = nullptr;
+        QPushButton *capture_button_ = nullptr;
+        QPushButton *start_video_button_ = nullptr;
+        QPushButton *stop_video_button_ = nullptr;
+        QLineEdit *still_output_edit_ = nullptr;
+        QLineEdit *video_output_edit_ = nullptr;
+        QSpinBox *width_spin_ = nullptr;
+        QSpinBox *height_spin_ = nullptr;
+        QDoubleSpinBox *framerate_spin_ = nullptr;
+        QComboBox *encoding_combo_ = nullptr;
+        QComboBox *codec_combo_ = nullptr;
+        QComboBox *bitrate_combo_ = nullptr;
+        QLabel *status_label_ = nullptr;
+};
+
+int main(int argc, char **argv)
+{
+        QApplication app(argc, argv);
+        MainWindow window;
+        window.setWindowTitle(QObject::tr("RPi Camera GUI"));
+        window.resize(1280, 720);
+        window.show();
+        return app.exec();
+}
+

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,10 @@ endif
 dl_dep = dependency('dl', required : true)
 libcamera_dep = dependency('libcamera', required : true)
 
+qt5_mod = import('qt5', required : get_option('enable_qt'))
+qt_dep = dependency('qt5', modules : ['Core', 'Widgets'], required : get_option('enable_qt'))
+enable_qt = qt_dep.found()
+
 if get_option('disable_rpi_features') == true
     cpp_arguments += '-DDISABLE_RPI_FEATURES'
 endif

--- a/preview/meson.build
+++ b/preview/meson.build
@@ -9,6 +9,7 @@ rpicam_app_src += files([
 
 preview_headers = files([
     'preview.hpp',
+    'qt_preview.hpp',
 ])
 
 enable_drm = false
@@ -44,10 +45,9 @@ if x11_deps.found() and epoxy_deps.found()
     enable_egl = true
 endif
 
-enable_qt = false
-qt_dep = dependency('qt5', modules : ['Core', 'Widgets'], required : get_option('enable_qt'))
 if qt_dep.found()
-    egl_lib = shared_module('qt-preview', files('qt_preview.cpp'),
+    qt_sources = qt5_mod.preprocess(moc_headers : ['qt_preview.hpp'])
+    egl_lib = shared_module('qt-preview', ['qt_preview.cpp'] + qt_sources,
                             include_directories : '../',
                             dependencies : [qt_dep, libcamera_dep],
                             cpp_args : cpp_arguments,
@@ -57,6 +57,8 @@ if qt_dep.found()
     )
     conf_data.set('QT_PRESENT', 1)
     enable_qt = true
+else
+    enable_qt = false
 endif
 
 install_headers(preview_headers, subdir: meson.project_name() / 'preview')

--- a/preview/qt_preview.cpp
+++ b/preview/qt_preview.cpp
@@ -1,228 +1,374 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (C) 2021, Raspberry Pi (Trading) Ltd.
+ * Copyright (C) 2021-2024, Raspberry Pi (Trading) Ltd.
  *
- * qt_preview.cpp - Qt preview window
+ * qt_preview.cpp - Qt preview widget used by CLI and GUI applications.
  */
 
+#include <algorithm>
 #include <condition_variable>
+#include <cstring>
 #include <iostream>
 #include <mutex>
-#include <string.h>
-#include <thread>
 
-// This header must be before the QT headers, as the latter #defines slot and emit!
 #include "core/options.hpp"
 
 #include <QApplication>
-#include <QImage>
 #include <QMainWindow>
-#include <QPaintEvent>
+#include <QMetaObject>
 #include <QPainter>
-#include <QWidget>
+#include <QPaintEvent>
+#include <QPointer>
+#include <QSizePolicy>
+#include <QThread>
+#include <QVBoxLayout>
 
-#include "preview.hpp"
+#include "qt_preview.hpp"
 
-class MyMainWindow : public QMainWindow
+namespace
+{
+
+class QtPreviewWindow : public QMainWindow
 {
 public:
-	MyMainWindow() : QMainWindow() {}
-	bool quit = false;
+        QtPreviewWindow() : QMainWindow() {}
+        bool quit = false;
+
 protected:
-	void closeEvent(QCloseEvent *event) override
-	{
-		event->ignore();
-		quit = true;
-	}
+        void closeEvent(QCloseEvent *event) override
+        {
+                event->ignore();
+                quit = true;
+        }
 };
 
-class MyWidget : public QWidget
+struct ColourMatrix
 {
-public:
-	MyWidget(QWidget *parent, int w, int h) : QWidget(parent), size(w, h)
-	{
-		image = QImage(size, QImage::Format_RGB888);
-		image.fill(0);
-	}
-	QSize size;
-	QImage image;
-protected:
-	void paintEvent(QPaintEvent *) override
-	{
-		QPainter painter(this);
-		painter.drawImage(rect(), image, image.rect());
-	}
-	QSize sizeHint() const override { return size; }
+        int offset_y;
+        float coeff_y;
+        float coeff_vr;
+        float coeff_ug;
+        float coeff_vg;
+        float coeff_ub;
 };
 
-class QtPreview : public Preview
+ColourMatrix selectColourMatrix(const StreamInfo &info)
 {
-public:
-	QtPreview(Options const *options) : Preview(options)
-	{
-		window_width_ = options->Get().preview_width;
-		window_height_ = options->Get().preview_height;
-		if (window_width_ % 2 || window_height_ % 2)
-			throw std::runtime_error("QtPreview: expect even dimensions");
-		// This preview window is expensive, so make it small by default.
-		if (window_width_ == 0 || window_height_ == 0)
-			window_width_ = 512, window_height_ = 384;
-		// As a hint, reserve twice the binned width for our widest current camera (V3)
-		tmp_stripe_.reserve(4608);
-		thread_ = std::thread(&QtPreview::threadFunc, this, options);
-		std::unique_lock lock(mutex_);
-		while (!pane_)
-			cond_var_.wait(lock);
-		LOG(2, "Made Qt preview");
-	}
-	~QtPreview()
-	{
-		application_->exit();
-		thread_.join();
-	}
-	void SetInfoText(const std::string &text) override { main_window_->setWindowTitle(QString::fromStdString(text)); }
-	virtual void Show(int fd, libcamera::Span<uint8_t> span, StreamInfo const &info) override
-	{
-		// Quick and simple nearest-neighbour-ish resampling is used here.
-		// We further share U,V samples between adjacent output pixel pairs
-		// (even when downscaling) to speed up the conversion.
-		unsigned x_step = (info.width << 16) / window_width_;
-		unsigned y_step = (info.height << 16) / window_height_;
+        static constexpr ColourMatrix matrices[3] = {
+                { 0, 1.0f, 1.402f, -0.344f, -0.714f, 1.772f },      // JPEG
+                { 16, 1.164f, 1.596f, -0.392f, -0.813f, 2.017f },  // SMPTE170M
+                { 16, 1.164f, 1.793f, -0.213f, -0.533f, 2.112f },  // Rec709
+        };
 
-		// Choose the right matrix to convert YUV back to RGB.
-		static const float YUV2RGB[3][9] = {
-			{ 1.0,   0.0, 1.402, 1.0,   -0.344, -0.714, 1.0,   1.772, 0.0 }, // JPEG
-			{ 1.164, 0.0, 1.596, 1.164, -0.392, -0.813, 1.164, 2.017, 0.0 }, // SMPTE170M
-			{ 1.164, 0.0, 1.793, 1.164, -0.213, -0.533, 1.164, 2.112, 0.0 }, // Rec709
-		};
-		int offsetY;
-		float coeffY, coeffVR, coeffUG, coeffVG, coeffUB;
-		if (info.colour_space == libcamera::ColorSpace::Smpte170m)
-		{
-			offsetY = 16;
-			coeffY = YUV2RGB[1][0];
-			coeffVR = YUV2RGB[1][2];
-			coeffUG = YUV2RGB[1][4];
-			coeffVG = YUV2RGB[1][5];
-			coeffUB = YUV2RGB[1][7];
-		}
-		else if (info.colour_space == libcamera::ColorSpace::Rec709)
-		{
-			offsetY = 16;
-			coeffY = YUV2RGB[2][0];
-			coeffVR = YUV2RGB[2][2];
-			coeffUG = YUV2RGB[2][4];
-			coeffVG = YUV2RGB[2][5];
-			coeffUB = YUV2RGB[2][7];
-		}
-		else
-		{
-			offsetY = 0;
-			coeffY = YUV2RGB[0][0];
-			coeffVR = YUV2RGB[0][2];
-			coeffUG = YUV2RGB[0][4];
-			coeffVG = YUV2RGB[0][5];
-			coeffUB = YUV2RGB[0][7];
-			if (info.colour_space != libcamera::ColorSpace::Sycc)
-				LOG(1, "QtPreview: unexpected colour space " << libcamera::ColorSpace::toString(info.colour_space));
-		}
+        if (info.colour_space == libcamera::ColorSpace::Smpte170m)
+                return matrices[1];
+        if (info.colour_space == libcamera::ColorSpace::Rec709)
+                return matrices[2];
+        if (info.colour_space && info.colour_space != libcamera::ColorSpace::Sycc)
+                LOG(1, "QtPreview: unexpected colour space " << libcamera::ColorSpace::toString(info.colour_space));
+        return matrices[0];
+}
 
-		// Because the source buffer is uncached, and we want to read it a byte at a time,
-		// take a copy of each row used. This is a speedup provided memcpy() is vectorized.
-		tmp_stripe_.resize(2 * info.stride);
-		uint8_t const *Y_start = span.data();
-		uint8_t *Y_row = &tmp_stripe_[0];
-		uint8_t *U_row = Y_row + info.stride;
-		uint8_t *V_row = U_row + (info.stride >> 1);
+} // namespace
 
-		// Possibly this should be locked in case a repaint is happening? In practice the risk
-		// is only that there might be some tearing, so I don't think we worry. We could speed
-		// it up by getting the ISP to supply RGB, but I'm not sure I want to handle that extra
-		// possibility in our main application code, so we'll put up with the slow conversion.
-		for (unsigned int y = 0; y < window_height_; y++)
-		{
-			unsigned row = (y * y_step) >> 16;
-			uint8_t *dest = pane_->image.scanLine(y);
-			unsigned x_pos = x_step >> 1;
+namespace QtPreviewIntegration
+{
+namespace
+{
+std::mutex &parentMutex()
+{
+        static std::mutex mutex;
+        return mutex;
+}
 
-			memcpy(Y_row, Y_start + row * info.stride, info.stride);
-			memcpy(U_row, Y_start + ((4 * info.height + row) >> 1) * (info.stride >> 1), info.stride >> 1);
-			memcpy(V_row, Y_start + ((5 * info.height + row) >> 1) * (info.stride >> 1), info.stride >> 1);
+QPointer<QWidget> &previewParent()
+{
+        static QPointer<QWidget> parent;
+        return parent;
+}
 
-			for (unsigned int x = 0; x < window_width_; x += 2)
-			{
-				int Y0 = Y_row[x_pos >> 16];
-				x_pos += x_step;
-				int Y1 = Y_row[x_pos >> 16];
-				int U = U_row[x_pos >> 17];
-				int V = V_row[x_pos >> 17];
-				x_pos += x_step;
-				Y0 -= offsetY;
-				Y1 -= offsetY;
-				U -= 128;
-				V -= 128;
-				int R0 = coeffY * Y0 + coeffVR * V;
-				int G0 = coeffY * Y0 + coeffUG * U + coeffVG * V;
-				int B0 = coeffY * Y0 + coeffUB * U;
-				int R1 = coeffY * Y1 + coeffVR * V;
-				int G1 = coeffY * Y1 + coeffUG * U + coeffVG * V;
-				int B1 = coeffY * Y1 + coeffUB * U;
-				*(dest++) = std::clamp(R0, 0, 255);
-				*(dest++) = std::clamp(G0, 0, 255);
-				*(dest++) = std::clamp(B0, 0, 255);
-				*(dest++) = std::clamp(R1, 0, 255);
-				*(dest++) = std::clamp(G1, 0, 255);
-				*(dest++) = std::clamp(B1, 0, 255);
-			}
-		}
+} // namespace
 
-		pane_->update();
+void registerPreviewParent(QWidget *parent)
+{
+        std::lock_guard<std::mutex> lock(parentMutex());
+        previewParent() = parent;
+}
 
-		// Return the buffer to the camera system.
-		done_callback_(fd);
-	}
-	// Reset the preview window, clearing the current buffers and being ready to
-	// show new ones.
-	void Reset() override {}
-	// Check if preview window has been shut down.
-	bool Quit() override { return main_window_->quit; }
-	// There is no particular limit to image sizes, though large images will be very slow.
-	virtual void MaxImageSize(unsigned int &w, unsigned int &h) const override { w = h = 0; }
+QWidget *takePreviewParent()
+{
+        std::lock_guard<std::mutex> lock(parentMutex());
+        QWidget *parent = previewParent();
+        previewParent().clear();
+        return parent;
+}
 
-private:
-	void threadFunc(Options const *options)
-	{
-		// This acts as Qt's event loop. Really Qt prefers to own the application's event loop
-		// but we've supplied our own and only want Qt for rendering. This works, but I
-		// wouldn't write a proper Qt application like this.
-		int argc = 0;
-		char **argv = NULL;
-		QApplication application(argc, argv);
-		application_ = &application;
-		MyMainWindow main_window;
-		main_window_ = &main_window;
-		MyWidget pane(&main_window, window_width_, window_height_);
-		main_window.setCentralWidget(&pane);
-		// Need to get the window border sizes (it seems to be unreasonably difficult...)
-		main_window.move(options->Get().preview_x + 2, options->Get().preview_y + 28);
-		main_window.show();
-		pane_ = &pane;
-		cond_var_.notify_one();
-		application.exec();
-	}
-	QApplication *application_ = nullptr;
-	MyMainWindow *main_window_ = nullptr;
-	MyWidget *pane_ = nullptr;
-	std::thread thread_;
-	unsigned int window_width_, window_height_;
-	std::mutex mutex_;
-	std::condition_variable cond_var_;
-	std::vector<uint8_t> tmp_stripe_;
-};
+} // namespace QtPreviewIntegration
+
+QtPreviewWidget::QtPreviewWidget(unsigned int width, unsigned int height, QWidget *parent)
+        : QWidget(parent), window_width_(width), window_height_(height)
+{
+        if (window_width_ % 2 || window_height_ % 2)
+                throw std::runtime_error("QtPreview: expect even dimensions");
+        if (!window_width_ || !window_height_)
+                window_width_ = 512, window_height_ = 384;
+        ensureImage();
+        tmp_stripe_.reserve(4608);
+        setAttribute(Qt::WA_OpaquePaintEvent);
+        setAttribute(Qt::WA_NoSystemBackground);
+}
+
+void QtPreviewWidget::ensureImage()
+{
+        if (image_.size() != QSize(window_width_, window_height_))
+        {
+                image_ = QImage(QSize(window_width_, window_height_), QImage::Format_RGB888);
+                image_.fill(Qt::black);
+        }
+}
+
+void QtPreviewWidget::renderFrame(const QByteArray &data, const QtFrameInfo &info)
+{
+        if (!image_.width() || !image_.height())
+                ensureImage();
+
+        const uint8_t *src = reinterpret_cast<const uint8_t *>(data.constData());
+        if (!src)
+                return;
+
+        unsigned x_step = (info.width << 16) / window_width_;
+        unsigned y_step = (info.height << 16) / window_height_;
+
+        ColourMatrix matrix;
+        matrix.offset_y = info.colour_matrix == 0 ? 0 : 16;
+        if (info.colour_matrix == 1)
+                matrix = { 16, 1.164f, 1.596f, -0.392f, -0.813f, 2.017f };
+        else if (info.colour_matrix == 2)
+                matrix = { 16, 1.164f, 1.793f, -0.213f, -0.533f, 2.112f };
+        else
+                matrix = { 0, 1.0f, 1.402f, -0.344f, -0.714f, 1.772f };
+
+        tmp_stripe_.resize(2 * info.stride);
+        uint8_t *Y_row = tmp_stripe_.data();
+        uint8_t *U_row = Y_row + info.stride;
+        uint8_t *V_row = U_row + (info.stride >> 1);
+
+        for (unsigned int y = 0; y < window_height_; y++)
+        {
+                unsigned row = (y * y_step) >> 16;
+                uint8_t *dest = image_.scanLine(y);
+                unsigned x_pos = x_step >> 1;
+
+                memcpy(Y_row, src + row * info.stride, info.stride);
+                memcpy(U_row, src + ((4 * info.height + row) >> 1) * (info.stride >> 1), info.stride >> 1);
+                memcpy(V_row, src + ((5 * info.height + row) >> 1) * (info.stride >> 1), info.stride >> 1);
+
+                for (unsigned int x = 0; x < window_width_; x += 2)
+                {
+                        int Y0 = Y_row[x_pos >> 16] - matrix.offset_y;
+                        x_pos += x_step;
+                        int Y1 = Y_row[x_pos >> 16] - matrix.offset_y;
+                        int U = U_row[x_pos >> 17] - 128;
+                        int V = V_row[x_pos >> 17] - 128;
+                        x_pos += x_step;
+
+                        int R0 = matrix.coeff_y * Y0 + matrix.coeff_vr * V;
+                        int G0 = matrix.coeff_y * Y0 + matrix.coeff_ug * U + matrix.coeff_vg * V;
+                        int B0 = matrix.coeff_y * Y0 + matrix.coeff_ub * U;
+                        int R1 = matrix.coeff_y * Y1 + matrix.coeff_vr * V;
+                        int G1 = matrix.coeff_y * Y1 + matrix.coeff_ug * U + matrix.coeff_vg * V;
+                        int B1 = matrix.coeff_y * Y1 + matrix.coeff_ub * U;
+
+                        *(dest++) = std::clamp(R0, 0, 255);
+                        *(dest++) = std::clamp(G0, 0, 255);
+                        *(dest++) = std::clamp(B0, 0, 255);
+                        *(dest++) = std::clamp(R1, 0, 255);
+                        *(dest++) = std::clamp(G1, 0, 255);
+                        *(dest++) = std::clamp(B1, 0, 255);
+                }
+        }
+
+        update();
+        emit frameUpdated();
+}
+
+void QtPreviewWidget::clearFrame()
+{
+        ensureImage();
+        image_.fill(Qt::black);
+        update();
+}
+
+void QtPreviewWidget::setInfoText(const QString &text)
+{
+        info_text_ = text;
+        update();
+}
+
+void QtPreviewWidget::paintEvent(QPaintEvent *event)
+{
+        Q_UNUSED(event);
+        QPainter painter(this);
+        painter.drawImage(rect(), image_, image_.rect());
+        if (!info_text_.isEmpty())
+        {
+                        painter.setPen(Qt::green);
+                        painter.drawText(rect().adjusted(8, 8, -8, -8), Qt::AlignTop | Qt::AlignLeft, info_text_);
+        }
+}
+
+QtPreview::QtPreview(Options const *options)
+        : Preview(options)
+{
+        qRegisterMetaType<QtFrameInfo>();
+
+        window_width_ = options->Get().preview_width;
+        window_height_ = options->Get().preview_height;
+        if (window_width_ % 2 || window_height_ % 2)
+                throw std::runtime_error("QtPreview: expect even dimensions");
+        if (!window_width_ || !window_height_)
+                window_width_ = 512, window_height_ = 384;
+
+        QWidget *parent = QtPreviewIntegration::takePreviewParent();
+        if (parent)
+        {
+                initialiseEmbeddedWidget(parent);
+        }
+        else
+        {
+                initialiseStandaloneWindow(options);
+        }
+}
+
+QtPreview::~QtPreview()
+{
+        if (owns_event_loop_)
+        {
+                if (application_)
+                        QMetaObject::invokeMethod(application_, "quit", Qt::QueuedConnection);
+                if (thread_.joinable())
+                        thread_.join();
+        }
+        else if (owns_widget_ && pane_)
+        {
+                pane_->deleteLater();
+        }
+}
+
+void QtPreview::initialiseEmbeddedWidget(QWidget *parent)
+{
+        pane_ = parent->findChild<QtPreviewWidget *>();
+        if (!pane_)
+        {
+                pane_ = new QtPreviewWidget(window_width_, window_height_, parent);
+                pane_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+                if (!parent->layout())
+                {
+                        auto *layout = new QVBoxLayout(parent);
+                        layout->setContentsMargins(0, 0, 0, 0);
+                        layout->addWidget(pane_);
+                }
+                else
+                        parent->layout()->addWidget(pane_);
+        }
+        owns_widget_ = false;
+}
+
+void QtPreview::initialiseStandaloneWindow(Options const *options)
+{
+        owns_event_loop_ = true;
+        thread_ = std::thread(&QtPreview::runStandaloneEventLoop, this, options);
+        std::unique_lock<std::mutex> lock(mutex_);
+        cond_var_.wait(lock, [this] { return pane_ != nullptr; });
+}
+
+void QtPreview::runStandaloneEventLoop(Options const *options)
+{
+        int argc = 0;
+        char **argv = nullptr;
+        QApplication application(argc, argv);
+        application_ = &application;
+
+        QtPreviewWindow main_window;
+        window_ = &main_window;
+        QtPreviewWidget pane(window_width_, window_height_, &main_window);
+        pane_ = &pane;
+        main_window.setCentralWidget(&pane);
+        main_window.move(options->Get().preview_x + 2, options->Get().preview_y + 28);
+        main_window.show();
+
+        {
+                std::lock_guard<std::mutex> lock(mutex_);
+                cond_var_.notify_all();
+        }
+
+        application.exec();
+        quit_ = true;
+        pane_ = nullptr;
+        window_ = nullptr;
+        application_ = nullptr;
+}
+
+void QtPreview::SetInfoText(const std::string &text)
+{
+        if (!pane_)
+                return;
+        QString info = QString::fromStdString(text);
+        QMetaObject::invokeMethod(pane_, "setInfoText", Qt::QueuedConnection, Q_ARG(QString, info));
+        if (window_)
+                QMetaObject::invokeMethod(window_, [window = window_, info]() { window->setWindowTitle(info); }, Qt::QueuedConnection);
+}
+
+void QtPreview::Show(int fd, libcamera::Span<uint8_t> span, StreamInfo const &info)
+{
+        if (!pane_)
+                return;
+
+        ColourMatrix matrix = selectColourMatrix(info);
+        QtFrameInfo frame_info;
+        frame_info.width = info.width;
+        frame_info.height = info.height;
+        frame_info.stride = info.stride;
+        if (matrix.offset_y == 16 && matrix.coeff_vr == 1.596f)
+                frame_info.colour_matrix = 1;
+        else if (matrix.offset_y == 16 && matrix.coeff_vr == 1.793f)
+                frame_info.colour_matrix = 2;
+        else
+                frame_info.colour_matrix = 0;
+
+        QByteArray data(reinterpret_cast<const char *>(span.data()), span.size());
+        QMetaObject::invokeMethod(pane_, "renderFrame", Qt::QueuedConnection, Q_ARG(QByteArray, data), Q_ARG(QtFrameInfo, frame_info));
+
+        if (done_callback_)
+                done_callback_(fd);
+}
+
+void QtPreview::Reset()
+{
+        if (!pane_)
+                return;
+        QMetaObject::invokeMethod(pane_, "clearFrame", Qt::QueuedConnection);
+}
+
+bool QtPreview::Quit()
+{
+        return quit_;
+}
+
+void QtPreview::MaxImageSize(unsigned int &w, unsigned int &h) const
+{
+        w = h = 0;
+}
+
+void QtPreview::RegisterPreviewParent(QWidget *parent)
+{
+        QtPreviewIntegration::registerPreviewParent(parent);
+}
 
 static Preview *Create(Options const *options)
 {
-	return new QtPreview(options);
+        return new QtPreview(options);
 }
 
 static RegisterPreview reg("qt", &Create);
+

--- a/preview/qt_preview.hpp
+++ b/preview/qt_preview.hpp
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2021-2024, Raspberry Pi (Trading) Ltd.
+ *
+ * qt_preview.hpp - Qt preview widget facade used by GUI and CLI applications.
+ */
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <QByteArray>
+#include <QImage>
+#include <QMetaType>
+#include <QPointer>
+#include <QString>
+#include <QWidget>
+
+#include "preview.hpp"
+
+struct QtFrameInfo
+{
+        unsigned int width = 0;
+        unsigned int height = 0;
+        unsigned int stride = 0;
+        int colour_matrix = 0;
+};
+
+Q_DECLARE_METATYPE(QtFrameInfo)
+
+class QtPreviewWidget : public QWidget
+{
+        Q_OBJECT
+
+public:
+        QtPreviewWidget(unsigned int width, unsigned int height, QWidget *parent = nullptr);
+
+public slots:
+        void renderFrame(const QByteArray &data, const QtFrameInfo &info);
+        void clearFrame();
+        void setInfoText(const QString &text);
+
+signals:
+        void frameUpdated();
+
+protected:
+        void paintEvent(QPaintEvent *event) override;
+        QSize sizeHint() const override { return QSize(window_width_, window_height_); }
+
+private:
+        void ensureImage();
+
+        unsigned int window_width_;
+        unsigned int window_height_;
+        QImage image_;
+        QString info_text_;
+        std::vector<uint8_t> tmp_stripe_;
+};
+
+class QtPreviewWindow;
+
+class QtPreview : public QObject, public Preview
+{
+        Q_OBJECT
+
+public:
+        explicit QtPreview(Options const *options);
+        ~QtPreview() override;
+
+        void SetInfoText(const std::string &text) override;
+        void Show(int fd, libcamera::Span<uint8_t> span, StreamInfo const &info) override;
+        void Reset() override;
+        bool Quit() override;
+        void MaxImageSize(unsigned int &w, unsigned int &h) const override;
+
+        QWidget *widget() const { return pane_; }
+
+        static void RegisterPreviewParent(QWidget *parent);
+
+private:
+        void initialiseStandaloneWindow(Options const *options);
+        void initialiseEmbeddedWidget(QWidget *parent);
+        void runStandaloneEventLoop(Options const *options);
+
+        QtPreviewWidget *pane_ = nullptr;
+        QtPreviewWindow *window_ = nullptr;
+        QApplication *application_ = nullptr;
+        std::thread thread_;
+        unsigned int window_width_ = 0;
+        unsigned int window_height_ = 0;
+        bool quit_ = false;
+        bool owns_widget_ = false;
+        bool owns_event_loop_ = false;
+        std::mutex mutex_;
+        std::condition_variable cond_var_;
+};
+
+namespace QtPreviewIntegration
+{
+void registerPreviewParent(QWidget *parent);
+QWidget *takePreviewParent();
+}
+


### PR DESCRIPTION
When compiling with gcc15, compiliation fails due to undeclared
uint8_t type, it requires <cstdint> header to be present.

This change adds this missing header.

Signed-off-by: Gyorgy Sarvari <skandigraun@gmail.com>