### PR TITLE
postprocess: tensorflow: Remove unused include

### DIFF
--- a/post_processing_stages/tf_stage.hpp
+++ b/post_processing_stages/tf_stage.hpp
@@ -13,7 +13,6 @@
 
 #include <libcamera/stream.h>
 
-#include "tensorflow/lite/builtin_op_data.h"
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/interpreter.h"
 #include "tensorflow/lite/kernels/register.h"


### PR DESCRIPTION
This causes build errors with the RPi libtensorflow-lite 2.20.0 package.